### PR TITLE
feat: running isort to organize imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 You can get your QStash token from the [Upstash Console](https://console.upstash.com/qstash).
 
 #### Publish a JSON message
+
 ```python
 from upstash_qstash import Client
 
@@ -29,6 +30,7 @@ print(res["messageId"])
 ```
 
 #### [Create a scheduled message](https://upstash.com/docs/qstash/features/schedules)
+
 ```python
 from upstash_qstash import Client
 
@@ -45,6 +47,7 @@ print(res["scheduleId"])
 ```
 
 #### [Receiving messages](https://upstash.com/docs/qstash/howto/receiving)
+
 ```python
 from upstash_qstash import Receiver
 
@@ -70,10 +73,11 @@ is_valid = receiver.verify(
 ```
 
 #### Additional configuration
+
 ```python
 from upstash_qstash import Client
 
-# Create a client with a custom retry configuration. This is 
+# Create a client with a custom retry configuration. This is
 # for sending messages to QStash, not for sending messages to
 # your endpoints.
 # The default configuration is:
@@ -109,7 +113,7 @@ client.publish_json(
     # https://upstash.com/docs/qstash/features/retry
     "retries": 3,
     # Schedule message to be sent 4 seconds from now
-    "delay": 4, 
+    "delay": 4,
     # When message is sent, send a request to this URL
     # https://upstash.com/docs/qstash/features/callbacks
     "callback": "https://my-api.com/callback",
@@ -129,9 +133,10 @@ client.publish_json(
 Additional methods are available for managing topics, schedules, and messages. See the examples folder for more.
 
 ### Development
+
 1. Clone the repository
 2. Install [Poetry](https://python-poetry.org/docs/#installation)
 3. Install dependencies with `poetry install`
 4. Create a .env file with `cp .env.example .env` and fill in the `QSTASH_TOKEN`
 5. Run tests with `poetry run pytest` and examples with `python3 examples/<example>.py`
-6. Format with `poetry run black .`
+6. Format with `poetry run black . && poetry run isort .`

--- a/examples/async_publish.py
+++ b/examples/async_publish.py
@@ -3,8 +3,9 @@ Uses asyncio to asynchronously publish a JSON message with a 3s delay to a URL u
 """
 
 import asyncio
-from upstash_qstash.asyncio import Client
+
 from qstash_tokens import QSTASH_TOKEN
+from upstash_qstash.asyncio import Client
 
 
 async def main():

--- a/examples/async_vs_blocking_publish.py
+++ b/examples/async_vs_blocking_publish.py
@@ -3,11 +3,12 @@ Send 3 messages to a URL using the blocking client and 3 messages to a URL using
 Demonstrate the difference in behavior between blocking and async operations with added artificial delay.
 """
 
-from upstash_qstash import Client as BlockingClient
-from upstash_qstash.asyncio import Client as AsyncClient
 import asyncio
 import time
+
 from qstash_tokens import QSTASH_TOKEN
+from upstash_qstash import Client as BlockingClient
+from upstash_qstash.asyncio import Client as AsyncClient
 
 # Artificial delay (in seconds)
 DELAY = 2

--- a/examples/basic_publish.py
+++ b/examples/basic_publish.py
@@ -2,8 +2,8 @@
 Publishes a JSON message with a 3s delay to a URL using QStash.
 """
 
-from upstash_qstash import Client
 from qstash_tokens import QSTASH_TOKEN
+from upstash_qstash import Client
 
 
 def main():

--- a/examples/basic_schedule.py
+++ b/examples/basic_schedule.py
@@ -5,8 +5,8 @@ existing schedules.
 Also an example of how to use the schedules API (list, create, delete, get).
 """
 
-from upstash_qstash import Client
 from qstash_tokens import QSTASH_TOKEN
+from upstash_qstash import Client
 
 
 def main():

--- a/examples/callback.py
+++ b/examples/callback.py
@@ -5,8 +5,8 @@ This is useful if you have a time consuming API call (ie: OpenAI)
 and you want to send the response to your API URL without having
 to wait for the response in a serverless function.
 """
-from upstash_qstash import Client
 from qstash_tokens import QSTASH_TOKEN
+from upstash_qstash import Client
 
 
 def main():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ python-dotenv = "^1.0.0"
 pytest-asyncio = "^0.23.3"
 mypy = "^1.8.0"
 types-requests = "^2.31.0.20240106"
+isort = "^5.13.2"
+
+[tool.isort]
+profile = "black"
 
 [build-system]
 requires = ["poetry-core"]

--- a/qstash_tokens.py
+++ b/qstash_tokens.py
@@ -1,4 +1,5 @@
 import os
+
 import dotenv
 
 QSTASH_TOKEN = os.environ.get(

--- a/tests/asyncio/test_dlq.py
+++ b/tests/asyncio/test_dlq.py
@@ -1,7 +1,9 @@
-import pytest
 import asyncio
-from upstash_qstash.asyncio import Client
+
+import pytest
+
 from qstash_tokens import QSTASH_TOKEN
+from upstash_qstash.asyncio import Client
 
 
 @pytest.fixture

--- a/tests/asyncio/test_keys.py
+++ b/tests/asyncio/test_keys.py
@@ -1,10 +1,11 @@
 import pytest
-from upstash_qstash.asyncio import Client
+
 from qstash_tokens import (
-    QSTASH_TOKEN,
     QSTASH_CURRENT_SIGNING_KEY,
     QSTASH_NEXT_SIGNING_KEY,
+    QSTASH_TOKEN,
 )
+from upstash_qstash.asyncio import Client
 
 
 @pytest.fixture

--- a/tests/asyncio/test_publish.py
+++ b/tests/asyncio/test_publish.py
@@ -1,7 +1,9 @@
-import pytest
 import asyncio
-from upstash_qstash.asyncio import Client
+
+import pytest
+
 from qstash_tokens import QSTASH_TOKEN
+from upstash_qstash.asyncio import Client
 
 
 @pytest.fixture

--- a/tests/asyncio/test_queue.py
+++ b/tests/asyncio/test_queue.py
@@ -1,6 +1,7 @@
 import pytest
-from upstash_qstash.asyncio import Client
+
 from qstash_tokens import QSTASH_TOKEN
+from upstash_qstash.asyncio import Client
 
 
 @pytest.fixture

--- a/tests/asyncio/test_schedules.py
+++ b/tests/asyncio/test_schedules.py
@@ -1,7 +1,9 @@
-import pytest
 import asyncio
-from upstash_qstash.asyncio import Client
+
+import pytest
+
 from qstash_tokens import QSTASH_TOKEN
+from upstash_qstash.asyncio import Client
 
 
 @pytest.fixture

--- a/tests/asyncio/test_topics.py
+++ b/tests/asyncio/test_topics.py
@@ -1,8 +1,10 @@
-import pytest
 import asyncio
 import time
-from upstash_qstash.asyncio import Client
+
+import pytest
+
 from qstash_tokens import QSTASH_TOKEN
+from upstash_qstash.asyncio import Client
 
 
 @pytest.fixture

--- a/tests/test_dlq.py
+++ b/tests/test_dlq.py
@@ -1,7 +1,9 @@
-import pytest
 import time
-from upstash_qstash import Client
+
+import pytest
+
 from qstash_tokens import QSTASH_TOKEN
+from upstash_qstash import Client
 
 
 @pytest.fixture

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,10 +1,11 @@
 import pytest
-from upstash_qstash import Client
+
 from qstash_tokens import (
-    QSTASH_TOKEN,
     QSTASH_CURRENT_SIGNING_KEY,
     QSTASH_NEXT_SIGNING_KEY,
+    QSTASH_TOKEN,
 )
+from upstash_qstash import Client
 
 
 @pytest.fixture

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,8 +1,10 @@
-import pytest
 import time
+
+import pytest
+
+from qstash_tokens import QSTASH_TOKEN
 from upstash_qstash import Client
 from upstash_qstash.error import QstashException
-from qstash_tokens import QSTASH_TOKEN
 
 
 @pytest.fixture

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,6 +1,7 @@
 import pytest
-from upstash_qstash import Client
+
 from qstash_tokens import QSTASH_TOKEN
+from upstash_qstash import Client
 
 
 @pytest.fixture

--- a/tests/test_receiver.py
+++ b/tests/test_receiver.py
@@ -1,11 +1,13 @@
-import pytest
-import json
-import jwt
-import time
-import hashlib
 import base64
-from upstash_qstash import Receiver
+import hashlib
+import json
+import time
+
+import jwt
+import pytest
+
 from qstash_tokens import QSTASH_CURRENT_SIGNING_KEY, QSTASH_NEXT_SIGNING_KEY
+from upstash_qstash import Receiver
 from upstash_qstash.error import SignatureException
 
 

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1,7 +1,9 @@
-import pytest
 import time
-from upstash_qstash import Client
+
+import pytest
+
 from qstash_tokens import QSTASH_TOKEN
+from upstash_qstash import Client
 
 
 @pytest.fixture

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -1,7 +1,9 @@
-import pytest
 import time
-from upstash_qstash import Client
+
+import pytest
+
 from qstash_tokens import QSTASH_TOKEN
+from upstash_qstash import Client
 
 
 @pytest.fixture

--- a/upstash_qstash/asyncio/client.py
+++ b/upstash_qstash/asyncio/client.py
@@ -1,14 +1,15 @@
 from typing import Optional, Union
-from upstash_qstash.upstash_http import HttpClient
-from upstash_qstash.qstash_types import RetryConfig
-from upstash_qstash.asyncio.publish import Publish, PublishRequest, BatchRequest
-from upstash_qstash.asyncio.messages import Messages
-from upstash_qstash.asyncio.topics import Topics
+
 from upstash_qstash.asyncio.dlq import DLQ
-from upstash_qstash.asyncio.queue import Queue, QueueOpts
-from upstash_qstash.asyncio.schedules import Schedules
 from upstash_qstash.asyncio.events import Events, EventsRequest, GetEventsResponse
 from upstash_qstash.asyncio.keys import Keys
+from upstash_qstash.asyncio.messages import Messages
+from upstash_qstash.asyncio.publish import BatchRequest, Publish, PublishRequest
+from upstash_qstash.asyncio.queue import Queue, QueueOpts
+from upstash_qstash.asyncio.schedules import Schedules
+from upstash_qstash.asyncio.topics import Topics
+from upstash_qstash.qstash_types import RetryConfig
+from upstash_qstash.upstash_http import HttpClient
 
 DEFAULT_BASE_URL = "https://qstash.upstash.io"
 

--- a/upstash_qstash/asyncio/dlq.py
+++ b/upstash_qstash/asyncio/dlq.py
@@ -1,14 +1,15 @@
+import json
 from typing import Optional
-from upstash_qstash.upstash_http import HttpClient
+
 from upstash_qstash.dlq import (
-    ListMessagesOpts,
-    ListMessageResponse,
-    DlqMessage,
     BulkDeleteRequest,
     BulkDeleteResponse,
+    DlqMessage,
+    ListMessageResponse,
+    ListMessagesOpts,
 )
 from upstash_qstash.qstash_types import UpstashRequest
-import json
+from upstash_qstash.upstash_http import HttpClient
 
 
 class DLQ:

--- a/upstash_qstash/asyncio/events.py
+++ b/upstash_qstash/asyncio/events.py
@@ -1,6 +1,7 @@
 from typing import Optional
-from upstash_qstash.upstash_http import HttpClient
+
 from upstash_qstash.events import EventsRequest, GetEventsResponse
+from upstash_qstash.upstash_http import HttpClient
 
 
 class Events:

--- a/upstash_qstash/asyncio/keys.py
+++ b/upstash_qstash/asyncio/keys.py
@@ -1,5 +1,5 @@
-from upstash_qstash.upstash_http import HttpClient
 from upstash_qstash.keys import GetKeysResponse
+from upstash_qstash.upstash_http import HttpClient
 
 
 class Keys:

--- a/upstash_qstash/asyncio/publish.py
+++ b/upstash_qstash/asyncio/publish.py
@@ -1,13 +1,14 @@
 import json
-from typing import Union, List
-from upstash_qstash.upstash_http import HttpClient
-from upstash_qstash.publish import (
-    PublishToUrlResponse,
-    PublishToTopicResponse,
-    PublishRequest,
-    BatchRequest,
-)
+from typing import List, Union
+
+from upstash_qstash.publish import BatchRequest
 from upstash_qstash.publish import Publish as SyncPublish
+from upstash_qstash.publish import (
+    PublishRequest,
+    PublishToTopicResponse,
+    PublishToUrlResponse,
+)
+from upstash_qstash.upstash_http import HttpClient
 
 
 class Publish:

--- a/upstash_qstash/asyncio/queue.py
+++ b/upstash_qstash/asyncio/queue.py
@@ -1,17 +1,14 @@
 import json
-from typing import List, Union, Optional
+from typing import List, Optional, Union
+
+from upstash_qstash.publish import Publish, PublishToTopicResponse, PublishToUrlResponse
 from upstash_qstash.queue import (
-    UpsertQueueRequest,
-    QueueResponse,
     EnqueueRequest,
     QueueOpts,
+    QueueResponse,
+    UpsertQueueRequest,
 )
 from upstash_qstash.upstash_http import HttpClient
-from upstash_qstash.publish import (
-    Publish,
-    PublishToUrlResponse,
-    PublishToTopicResponse,
-)
 
 
 class Queue:

--- a/upstash_qstash/asyncio/schedules.py
+++ b/upstash_qstash/asyncio/schedules.py
@@ -1,11 +1,12 @@
 from typing import List
-from upstash_qstash.upstash_http import HttpClient
+
 from upstash_qstash.schedules import (
-    Schedule,
     CreateScheduleRequest,
     CreateScheduleResponse,
-    Schedules as SyncSchedules,
+    Schedule,
 )
+from upstash_qstash.schedules import Schedules as SyncSchedules
+from upstash_qstash.upstash_http import HttpClient
 
 
 class Schedules:

--- a/upstash_qstash/asyncio/topics.py
+++ b/upstash_qstash/asyncio/topics.py
@@ -1,12 +1,9 @@
-from typing import List
-from upstash_qstash.upstash_http import HttpClient
-from upstash_qstash.topics import (
-    AddEndpointsRequest,
-    RemoveEndpointsRequest,
-    Topic,
-    Topics as SyncTopics,
-)
 import json
+from typing import List
+
+from upstash_qstash.topics import AddEndpointsRequest, RemoveEndpointsRequest, Topic
+from upstash_qstash.topics import Topics as SyncTopics
+from upstash_qstash.upstash_http import HttpClient
 
 
 class Topics:

--- a/upstash_qstash/client.py
+++ b/upstash_qstash/client.py
@@ -1,14 +1,15 @@
 from typing import Optional, Union
-from upstash_qstash.upstash_http import HttpClient
-from upstash_qstash.qstash_types import RetryConfig
-from upstash_qstash.publish import Publish, PublishRequest, BatchRequest
-from upstash_qstash.messages import Messages
-from upstash_qstash.topics import Topics
+
 from upstash_qstash.dlq import DLQ
-from upstash_qstash.queue import Queue, QueueOpts
 from upstash_qstash.events import Events, EventsRequest, GetEventsResponse
-from upstash_qstash.schedules import Schedules
 from upstash_qstash.keys import Keys
+from upstash_qstash.messages import Messages
+from upstash_qstash.publish import BatchRequest, Publish, PublishRequest
+from upstash_qstash.qstash_types import RetryConfig
+from upstash_qstash.queue import Queue, QueueOpts
+from upstash_qstash.schedules import Schedules
+from upstash_qstash.topics import Topics
+from upstash_qstash.upstash_http import HttpClient
 
 DEFAULT_BASE_URL = "https://qstash.upstash.io"
 

--- a/upstash_qstash/dlq.py
+++ b/upstash_qstash/dlq.py
@@ -1,7 +1,8 @@
-from typing import Optional, TypedDict, List, Dict
+import json
+from typing import Dict, List, Optional, TypedDict
+
 from upstash_qstash.qstash_types import Method, UpstashRequest
 from upstash_qstash.upstash_http import HttpClient
-import json
 
 DlqMessage = TypedDict(
     "DlqMessage",

--- a/upstash_qstash/events.py
+++ b/upstash_qstash/events.py
@@ -1,5 +1,6 @@
-from typing import TypedDict, Optional, List
 from enum import Enum
+from typing import List, Optional, TypedDict
+
 from upstash_qstash.upstash_http import HttpClient
 
 

--- a/upstash_qstash/keys.py
+++ b/upstash_qstash/keys.py
@@ -1,5 +1,6 @@
-from upstash_qstash.upstash_http import HttpClient
 from typing import TypedDict
+
+from upstash_qstash.upstash_http import HttpClient
 
 GetKeysResponse = TypedDict(
     "GetKeysResponse",

--- a/upstash_qstash/messages.py
+++ b/upstash_qstash/messages.py
@@ -1,4 +1,5 @@
-from typing import TypedDict, Optional, Dict, List
+from typing import Dict, List, Optional, TypedDict
+
 from upstash_qstash.qstash_types import Method
 from upstash_qstash.upstash_http import HttpClient
 

--- a/upstash_qstash/publish.py
+++ b/upstash_qstash/publish.py
@@ -1,9 +1,10 @@
-from typing import Optional, Dict, Any, TypedDict, List, Union
+import json
+from typing import Any, Dict, List, Optional, TypedDict, Union
+
+from upstash_qstash.error import QstashException
 from upstash_qstash.qstash_types import Method, UpstashHeaders
 from upstash_qstash.upstash_http import HttpClient
-from upstash_qstash.error import QstashException
 from upstash_qstash.utils import prefix_headers
-import json
 
 PublishRequest = TypedDict(
     "PublishRequest",

--- a/upstash_qstash/qstash_types.py
+++ b/upstash_qstash/qstash_types.py
@@ -1,5 +1,4 @@
-from typing import Optional, Dict, Any, List, TypedDict, Callable, Literal, Union
-
+from typing import Any, Callable, Dict, List, Literal, Optional, TypedDict, Union
 
 Method = Union[
     Literal["GET"], Literal["POST"], Literal["PUT"], Literal["DELETE"], Literal["PATCH"]

--- a/upstash_qstash/queue.py
+++ b/upstash_qstash/queue.py
@@ -1,12 +1,13 @@
 import json
-from typing import TypedDict, List, Union, Optional
-from upstash_qstash.upstash_http import HttpClient
+from typing import List, Optional, TypedDict, Union
+
 from upstash_qstash.publish import (
     Publish,
     PublishRequest,
-    PublishToUrlResponse,
     PublishToTopicResponse,
+    PublishToUrlResponse,
 )
+from upstash_qstash.upstash_http import HttpClient
 
 UpsertQueueRequest = TypedDict(
     "UpsertQueueRequest",

--- a/upstash_qstash/receiver.py
+++ b/upstash_qstash/receiver.py
@@ -1,7 +1,9 @@
-import hashlib
-import jwt
 import base64
-from typing import TypedDict, Optional
+import hashlib
+from typing import Optional, TypedDict
+
+import jwt
+
 from upstash_qstash.error import SignatureException
 
 ReceiverConfig = TypedDict(

--- a/upstash_qstash/schedules.py
+++ b/upstash_qstash/schedules.py
@@ -1,9 +1,10 @@
 import json
-from typing import TypedDict, List, Dict, Optional
+from typing import Dict, List, Optional, TypedDict
+
+from upstash_qstash.error import QstashException
 from upstash_qstash.qstash_types import Method, UpstashHeaders
 from upstash_qstash.upstash_http import HttpClient
 from upstash_qstash.utils import prefix_headers
-from upstash_qstash.error import QstashException
 
 Schedule = TypedDict(
     "Schedule",

--- a/upstash_qstash/topics.py
+++ b/upstash_qstash/topics.py
@@ -1,7 +1,8 @@
-from typing import Optional, TypedDict, List, Union
-from upstash_qstash.upstash_http import HttpClient
-from upstash_qstash.error import QstashException
 import json
+from typing import List, Optional, TypedDict, Union
+
+from upstash_qstash.error import QstashException
+from upstash_qstash.upstash_http import HttpClient
 
 Endpoint = TypedDict(
     "Endpoint",

--- a/upstash_qstash/upstash_http.py
+++ b/upstash_qstash/upstash_http.py
@@ -1,12 +1,14 @@
-import requests
+import asyncio
 import math
 import time
-import aiohttp
-import asyncio
-from typing import Union, Optional
+from typing import Optional, Union
 from urllib.parse import urlencode
-from upstash_qstash.qstash_types import UpstashRequest, RetryConfig, UpstashHeaders
+
+import aiohttp
+import requests
+
 from upstash_qstash.error import QstashException, QstashRateLimitException
+from upstash_qstash.qstash_types import RetryConfig, UpstashHeaders, UpstashRequest
 
 NO_RETRY: RetryConfig = {"attempts": 1, "backoff": lambda _: 0}
 DEFAULT_RETRY_CONFIG: RetryConfig = {


### PR DESCRIPTION
# isort

Running [isort](https://pycqa.github.io/isort/) to organize imports

- Include `isort` as dev dependency
- Change README to run `isort` with `black`
- Specify isort profile = `black` to avoid any conflict

isort uses as default:
1. FUTURE
2. STDLIB
3. THIRDPARTY
4. LOCALFOLDER
5. FIRSTPARTY
