### PR TITLE
Set timeout to a higher value

### DIFF
--- a/upstash_qstash/asyncio/http.py
+++ b/upstash_qstash/asyncio/http.py
@@ -10,6 +10,7 @@ from upstash_qstash.http import (
     HttpMethod,
     RetryConfig,
     raise_for_non_ok_status,
+    DEFAULT_TIMEOUT,
 )
 
 
@@ -28,7 +29,9 @@ class AsyncHttpClient:
         else:
             self._retry = retry
 
-        self._client = httpx.AsyncClient()
+        self._client = httpx.AsyncClient(
+            timeout=DEFAULT_TIMEOUT,
+        )
 
     async def request(
         self,

--- a/upstash_qstash/http.py
+++ b/upstash_qstash/http.py
@@ -15,6 +15,11 @@ class RetryConfig(TypedDict, total=False):
     """A function that returns how many milliseconds to backoff before the given retry attempt."""
 
 
+DEFAULT_TIMEOUT = httpx.Timeout(
+    timeout=600.0,
+    connect=5.0,
+)
+
 DEFAULT_RETRY = RetryConfig(
     retries=5,
     backoff=lambda retry_count: math.exp(1 + retry_count) * 50,
@@ -60,7 +65,9 @@ class HttpClient:
         else:
             self._retry = retry
 
-        self._client = httpx.Client()
+        self._client = httpx.Client(
+            timeout=DEFAULT_TIMEOUT,
+        )
 
     def request(
         self,


### PR DESCRIPTION
The default read timeout for httpx is 5 seconds, it is not enough for some long running chat completion requests.

Therefore, I set the default timeout value to something higher.

Note that, previously, when using requests library, we were using the default timeout, which was infinite. I set this new timeout to 10 minutes, which should be enough almost all the time.