### PR TITLE
Raise a specific error for chat rate limits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ pytest = "^8.2.2"
 python-dotenv = "^1.0.1"
 pytest-asyncio = "^0.23.7"
 mypy = "^1.10.0"
-ruff = "^0.4.8"
+ruff = "^0.5.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/upstash_qstash/errors.py
+++ b/upstash_qstash/errors.py
@@ -19,3 +19,26 @@ class RateLimitExceededError(QStashError):
         self.limit = limit
         self.remaining = remaining
         self.reset = reset
+
+
+class ChatRateLimitExceededError(QStashError):
+    def __init__(
+        self,
+        limit_requests: Optional[str],
+        limit_tokens: Optional[str],
+        remaining_requests: Optional[str],
+        remaining_tokens: Optional[str],
+        reset_requests: Optional[str],
+        reset_tokens: Optional[str],
+    ):
+        super(
+            f"Exceeded chat rate limit: "
+            f"Request limit: {limit_requests}, remaining: {remaining_requests}, reset: {reset_requests}; "
+            f"token limit: {limit_tokens}, remaining: {remaining_tokens}, reset: {reset_tokens}"
+        )
+        self.limit_requests = limit_requests
+        self.limit_tokens = limit_tokens
+        self.remaining_requests = remaining_requests
+        self.remaining_tokens = remaining_tokens
+        self.reset_requests = reset_requests
+        self.reset_tokens = reset_tokens


### PR DESCRIPTION
This part was not ported when rewriting the client, so I added it back.

Also, updated the ruff dev dependency to the latest version.