### PR TITLE
Handle daily rate limit error separately

### DIFF
--- a/upstash_qstash/errors.py
+++ b/upstash_qstash/errors.py
@@ -14,7 +14,19 @@ class RateLimitExceededError(QStashError):
         self, limit: Optional[str], remaining: Optional[str], reset: Optional[str]
     ):
         super().__init__(
-            f"Exceeded rate limit: Limit: {limit}, remaining: {remaining}, reset: {reset}"
+            f"Exceeded burst rate limit: Limit: {limit}, remaining: {remaining}, reset: {reset}"
+        )
+        self.limit = limit
+        self.remaining = remaining
+        self.reset = reset
+
+
+class DailyMessageLimitExceededError(QStashError):
+    def __init__(
+        self, limit: Optional[str], remaining: Optional[str], reset: Optional[str]
+    ):
+        super().__init__(
+            f"Exceeded daily message limit: Limit: {limit}, remaining: {remaining}, reset: {reset}"
         )
         self.limit = limit
         self.remaining = remaining


### PR DESCRIPTION
We raise 429 status code on two occasions:

- When the burst rate limit is exceeded, if the user published too many messages in a short amount of time
- When the daily max message limit is exceeded

We were assuming that when the 429 status code is received it was always the first case, but it is not.

This PR adds the logic to handle this. Since it is hard to test it against the production QStash instance we use in tests, I didn't write any; but manually verified that it works.