### PR TITLE
Add Optional base_url Parameter to Clients

### DIFF
--- a/qstash/asyncio/client.py
+++ b/qstash/asyncio/client.py
@@ -27,7 +27,7 @@ class AsyncQStash:
         http = AsyncHttpClient(
             token,
             retry,
-            base_url=(base_url or "https://qstash.upstash.io"),
+            base_url,
         )
         self.message = AsyncMessageApi(http)
         """Message api."""

--- a/qstash/asyncio/client.py
+++ b/qstash/asyncio/client.py
@@ -18,12 +18,19 @@ class AsyncQStash:
         token: str,
         *,
         retry: Optional[Union[Literal[False], RetryConfig]] = None,
+        base_url: Optional[str] = None,
     ) -> None:
         """
         :param token: The authorization token from the Upstash console.
         :param retry: Configures how the client should retry requests.
         """
-        http = AsyncHttpClient(token, retry)
+        http = AsyncHttpClient(
+            token,
+            retry,
+            base_url=(
+                base_url.rstrip("/") if base_url else "https://qstash.upstash.io"
+            ),
+        )
         self.message = AsyncMessageApi(http)
         """Message api."""
 

--- a/qstash/asyncio/client.py
+++ b/qstash/asyncio/client.py
@@ -27,9 +27,7 @@ class AsyncQStash:
         http = AsyncHttpClient(
             token,
             retry,
-            base_url=(
-                base_url.rstrip("/") if base_url else "https://qstash.upstash.io"
-            ),
+            base_url=(base_url or "https://qstash.upstash.io"),
         )
         self.message = AsyncMessageApi(http)
         """Message api."""

--- a/qstash/asyncio/http.py
+++ b/qstash/asyncio/http.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Literal, Optional, Union
 import httpx
 
 from qstash.http import (
+    BASE_URL,
     DEFAULT_RETRY,
     NO_RETRY,
     HttpMethod,
@@ -33,7 +34,7 @@ class AsyncHttpClient:
             timeout=DEFAULT_TIMEOUT,
         )
 
-        self._base_url = base_url.rstrip("/")
+        self._base_url = base_url
 
     async def request(
         self,
@@ -47,7 +48,7 @@ class AsyncHttpClient:
         base_url: Optional[str] = None,
         token: Optional[str] = None,
     ) -> Any:
-        base_url = base_url or self._base_url
+        base_url = base_url or self._base_url or BASE_URL
         token = token or self._token
 
         url = base_url + path
@@ -93,7 +94,7 @@ class AsyncHttpClient:
         base_url: Optional[str] = None,
         token: Optional[str] = None,
     ) -> httpx.Response:
-        base_url = base_url or self._base_url
+        base_url = base_url or self._base_url or BASE_URL
         token = token or self._token
 
         url = base_url + path

--- a/qstash/asyncio/http.py
+++ b/qstash/asyncio/http.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Literal, Optional, Union
 import httpx
 
 from qstash.http import (
-    BASE_URL,
     DEFAULT_RETRY,
     NO_RETRY,
     HttpMethod,
@@ -19,6 +18,7 @@ class AsyncHttpClient:
         self,
         token: str,
         retry: Optional[Union[Literal[False], RetryConfig]],
+        base_url: str,
     ) -> None:
         self._token = f"Bearer {token}"
 
@@ -33,6 +33,8 @@ class AsyncHttpClient:
             timeout=DEFAULT_TIMEOUT,
         )
 
+        self._base_url = base_url.rstrip("/")
+
     async def request(
         self,
         *,
@@ -45,7 +47,7 @@ class AsyncHttpClient:
         base_url: Optional[str] = None,
         token: Optional[str] = None,
     ) -> Any:
-        base_url = base_url or BASE_URL
+        base_url = base_url or self._base_url
         token = token or self._token
 
         url = base_url + path
@@ -91,7 +93,7 @@ class AsyncHttpClient:
         base_url: Optional[str] = None,
         token: Optional[str] = None,
     ) -> httpx.Response:
-        base_url = base_url or BASE_URL
+        base_url = base_url or self._base_url
         token = token or self._token
 
         url = base_url + path

--- a/qstash/asyncio/http.py
+++ b/qstash/asyncio/http.py
@@ -34,7 +34,7 @@ class AsyncHttpClient:
             timeout=DEFAULT_TIMEOUT,
         )
 
-        self._base_url = base_url
+        self._base_url = base_url.rstrip("/") if base_url else BASE_URL
 
     async def request(
         self,
@@ -48,7 +48,7 @@ class AsyncHttpClient:
         base_url: Optional[str] = None,
         token: Optional[str] = None,
     ) -> Any:
-        base_url = base_url or self._base_url or BASE_URL
+        base_url = base_url or self._base_url
         token = token or self._token
 
         url = base_url + path
@@ -94,7 +94,7 @@ class AsyncHttpClient:
         base_url: Optional[str] = None,
         token: Optional[str] = None,
     ) -> httpx.Response:
-        base_url = base_url or self._base_url or BASE_URL
+        base_url = base_url or self._base_url
         token = token or self._token
 
         url = base_url + path

--- a/qstash/asyncio/http.py
+++ b/qstash/asyncio/http.py
@@ -19,7 +19,7 @@ class AsyncHttpClient:
         self,
         token: str,
         retry: Optional[Union[Literal[False], RetryConfig]],
-        base_url: str,
+        base_url: Optional[str] = None,
     ) -> None:
         self._token = f"Bearer {token}"
 

--- a/qstash/client.py
+++ b/qstash/client.py
@@ -28,9 +28,7 @@ class QStash:
         http = HttpClient(
             token,
             retry,
-            base_url=(
-                base_url.rstrip("/") if base_url else "https://qstash.upstash.io"
-            ),
+            base_url=(base_url or "https://qstash.upstash.io"),
         )
         self.message = MessageApi(http)
         """Message api."""

--- a/qstash/client.py
+++ b/qstash/client.py
@@ -19,12 +19,19 @@ class QStash:
         token: str,
         *,
         retry: Optional[Union[Literal[False], RetryConfig]] = None,
+        base_url: Optional[str] = None,
     ) -> None:
         """
         :param token: The authorization token from the Upstash console.
         :param retry: Configures how the client should retry requests.
         """
-        http = HttpClient(token, retry)
+        http = HttpClient(
+            token,
+            retry,
+            base_url=(
+                base_url.rstrip("/") if base_url else "https://qstash.upstash.io"
+            ),
+        )
         self.message = MessageApi(http)
         """Message api."""
 

--- a/qstash/client.py
+++ b/qstash/client.py
@@ -28,7 +28,7 @@ class QStash:
         http = HttpClient(
             token,
             retry,
-            base_url=(base_url or "https://qstash.upstash.io"),
+            base_url,
         )
         self.message = MessageApi(http)
         """Message api."""

--- a/qstash/http.py
+++ b/qstash/http.py
@@ -35,8 +35,6 @@ NO_RETRY = RetryConfig(
     backoff=lambda _: 0,
 )
 
-BASE_URL = "https://qstash.upstash.io"
-
 HttpMethod = Literal["GET", "POST", "PUT", "DELETE", "PATCH"]
 
 
@@ -102,6 +100,7 @@ class HttpClient:
         self,
         token: str,
         retry: Optional[Union[Literal[False], RetryConfig]],
+        base_url: str,
     ) -> None:
         self._token = f"Bearer {token}"
 
@@ -116,6 +115,8 @@ class HttpClient:
             timeout=DEFAULT_TIMEOUT,
         )
 
+        self._base_url = base_url.rstrip("/")
+
     def request(
         self,
         *,
@@ -128,7 +129,7 @@ class HttpClient:
         base_url: Optional[str] = None,
         token: Optional[str] = None,
     ) -> Any:
-        base_url = base_url or BASE_URL
+        base_url = base_url or self._base_url
         token = token or self._token
 
         url = base_url + path
@@ -174,7 +175,7 @@ class HttpClient:
         base_url: Optional[str] = None,
         token: Optional[str] = None,
     ) -> httpx.Response:
-        base_url = base_url or BASE_URL
+        base_url = base_url or self._base_url
         token = token or self._token
 
         url = base_url + path

--- a/qstash/http.py
+++ b/qstash/http.py
@@ -117,7 +117,7 @@ class HttpClient:
             timeout=DEFAULT_TIMEOUT,
         )
 
-        self._base_url = base_url
+        self._base_url = base_url.rstrip("/") if base_url else BASE_URL
 
     def request(
         self,
@@ -131,7 +131,7 @@ class HttpClient:
         base_url: Optional[str] = None,
         token: Optional[str] = None,
     ) -> Any:
-        base_url = base_url or self._base_url or BASE_URL
+        base_url = base_url or self._base_url
         token = token or self._token
 
         url = base_url + path
@@ -177,7 +177,7 @@ class HttpClient:
         base_url: Optional[str] = None,
         token: Optional[str] = None,
     ) -> httpx.Response:
-        base_url = base_url or self._base_url or BASE_URL
+        base_url = base_url or self._base_url
         token = token or self._token
 
         url = base_url + path

--- a/qstash/http.py
+++ b/qstash/http.py
@@ -35,6 +35,8 @@ NO_RETRY = RetryConfig(
     backoff=lambda _: 0,
 )
 
+BASE_URL = "https://qstash.upstash.io"
+
 HttpMethod = Literal["GET", "POST", "PUT", "DELETE", "PATCH"]
 
 
@@ -115,7 +117,7 @@ class HttpClient:
             timeout=DEFAULT_TIMEOUT,
         )
 
-        self._base_url = base_url.rstrip("/")
+        self._base_url = base_url
 
     def request(
         self,
@@ -129,7 +131,7 @@ class HttpClient:
         base_url: Optional[str] = None,
         token: Optional[str] = None,
     ) -> Any:
-        base_url = base_url or self._base_url
+        base_url = base_url or self._base_url or BASE_URL
         token = token or self._token
 
         url = base_url + path
@@ -175,7 +177,7 @@ class HttpClient:
         base_url: Optional[str] = None,
         token: Optional[str] = None,
     ) -> httpx.Response:
-        base_url = base_url or self._base_url
+        base_url = base_url or self._base_url or BASE_URL
         token = token or self._token
 
         url = base_url + path

--- a/qstash/http.py
+++ b/qstash/http.py
@@ -102,7 +102,7 @@ class HttpClient:
         self,
         token: str,
         retry: Optional[Union[Literal[False], RetryConfig]],
-        base_url: str,
+        base_url: Optional[str] = None,
     ) -> None:
         self._token = f"Bearer {token}"
 


### PR DESCRIPTION
This PR adds the optional `base_url` parameter to QStash clients. This can be used to change the url of the QStash client for development/testing purposes.