### PR TITLE
DX-1614: Parallelism and Calls per second parameters

### DIFF
--- a/qstash/asyncio/message.py
+++ b/qstash/asyncio/message.py
@@ -269,6 +269,7 @@ class AsyncMessageApi:
             deduplication_id=deduplication_id,
             content_based_deduplication=content_based_deduplication,
             timeout=timeout,
+            flow_control=None,
         )
 
         response = await self._http.request(

--- a/qstash/asyncio/message.py
+++ b/qstash/asyncio/message.py
@@ -48,7 +48,7 @@ class AsyncMessageApi:
         deduplication_id: Optional[str] = None,
         content_based_deduplication: Optional[bool] = None,
         timeout: Optional[Union[str, int]] = None,
-        flow_control: Optional[FlowControl] = None
+        flow_control: Optional[FlowControl] = None,
     ) -> Union[PublishResponse, List[PublishUrlGroupResponse]]:
         """
         Publishes a message to QStash.
@@ -138,7 +138,7 @@ class AsyncMessageApi:
         deduplication_id: Optional[str] = None,
         content_based_deduplication: Optional[bool] = None,
         timeout: Optional[Union[str, int]] = None,
-        flow_control: Optional[FlowControl] = None
+        flow_control: Optional[FlowControl] = None,
     ) -> Union[PublishResponse, List[PublishUrlGroupResponse]]:
         """
         Publish a message to QStash, automatically serializing the

--- a/qstash/asyncio/message.py
+++ b/qstash/asyncio/message.py
@@ -5,6 +5,7 @@ from qstash.asyncio.http import AsyncHttpClient
 from qstash.http import HttpMethod
 from qstash.message import (
     ApiT,
+    FlowControl,
     BatchJsonRequest,
     BatchRequest,
     BatchResponse,
@@ -47,6 +48,7 @@ class AsyncMessageApi:
         deduplication_id: Optional[str] = None,
         content_based_deduplication: Optional[bool] = None,
         timeout: Optional[Union[str, int]] = None,
+        flow_control: Optional[FlowControl] = None
     ) -> Union[PublishResponse, List[PublishUrlGroupResponse]]:
         """
         Publishes a message to QStash.
@@ -84,6 +86,8 @@ class AsyncMessageApi:
             When a timeout is specified, it will be used instead of the maximum timeout
             value permitted by the QStash plan. It is useful in scenarios, where a message
             should be delivered with a shorter timeout.
+        :param flow_control: Settings for controlling the number of active requests and
+            number of requests per second with the same key.
         """
         headers = headers or {}
         destination = get_destination(
@@ -105,6 +109,7 @@ class AsyncMessageApi:
             deduplication_id=deduplication_id,
             content_based_deduplication=content_based_deduplication,
             timeout=timeout,
+            flow_control=flow_control,
         )
 
         response = await self._http.request(
@@ -133,6 +138,7 @@ class AsyncMessageApi:
         deduplication_id: Optional[str] = None,
         content_based_deduplication: Optional[bool] = None,
         timeout: Optional[Union[str, int]] = None,
+        flow_control: Optional[FlowControl] = None
     ) -> Union[PublishResponse, List[PublishUrlGroupResponse]]:
         """
         Publish a message to QStash, automatically serializing the
@@ -171,6 +177,8 @@ class AsyncMessageApi:
             When a timeout is specified, it will be used instead of the maximum timeout
             value permitted by the QStash plan. It is useful in scenarios, where a message
             should be delivered with a shorter timeout.
+        :param flow_control: Settings for controlling the number of active requests and
+            number of requests per second with the same key.
         """
         return await self.publish(
             url=url,
@@ -188,6 +196,7 @@ class AsyncMessageApi:
             deduplication_id=deduplication_id,
             content_based_deduplication=content_based_deduplication,
             timeout=timeout,
+            flow_control=flow_control,
         )
 
     async def enqueue(

--- a/qstash/asyncio/schedule.py
+++ b/qstash/asyncio/schedule.py
@@ -30,7 +30,7 @@ class AsyncScheduleApi:
         delay: Optional[Union[str, int]] = None,
         timeout: Optional[Union[str, int]] = None,
         schedule_id: Optional[str] = None,
-        flow_control: Optional[FlowControl] = None
+        flow_control: Optional[FlowControl] = None,
     ) -> str:
         """
         Creates a schedule to send messages periodically.
@@ -72,7 +72,7 @@ class AsyncScheduleApi:
             delay=delay,
             timeout=timeout,
             schedule_id=schedule_id,
-            flow_control=flow_control
+            flow_control=flow_control,
         )
 
         response = await self._http.request(
@@ -98,7 +98,7 @@ class AsyncScheduleApi:
         delay: Optional[Union[str, int]] = None,
         timeout: Optional[Union[str, int]] = None,
         schedule_id: Optional[str] = None,
-        flow_control: Optional[FlowControl] = None
+        flow_control: Optional[FlowControl] = None,
     ) -> str:
         """
         Creates a schedule to send messages periodically, automatically serializing the
@@ -143,7 +143,7 @@ class AsyncScheduleApi:
             delay=delay,
             timeout=timeout,
             schedule_id=schedule_id,
-            flow_control=flow_control
+            flow_control=flow_control,
         )
 
     async def get(self, schedule_id: str) -> Schedule:

--- a/qstash/asyncio/schedule.py
+++ b/qstash/asyncio/schedule.py
@@ -8,6 +8,7 @@ from qstash.schedule import (
     parse_schedule_response,
     prepare_schedule_headers,
 )
+from qstash.message import FlowControl
 
 
 class AsyncScheduleApi:
@@ -29,6 +30,7 @@ class AsyncScheduleApi:
         delay: Optional[Union[str, int]] = None,
         timeout: Optional[Union[str, int]] = None,
         schedule_id: Optional[str] = None,
+        flow_control: Optional[FlowControl] = None
     ) -> str:
         """
         Creates a schedule to send messages periodically.
@@ -56,6 +58,8 @@ class AsyncScheduleApi:
             value permitted by the QStash plan. It is useful in scenarios, where a message
             should be delivered with a shorter timeout.
         :param schedule_id: Schedule id to use. Can be used to update the settings of an existing schedule.
+        :param flow_control: Settings for controlling the number of active requests and
+            number of requests per second with the same key.
         """
         req_headers = prepare_schedule_headers(
             cron=cron,
@@ -68,6 +72,7 @@ class AsyncScheduleApi:
             delay=delay,
             timeout=timeout,
             schedule_id=schedule_id,
+            flow_control=flow_control
         )
 
         response = await self._http.request(
@@ -93,6 +98,7 @@ class AsyncScheduleApi:
         delay: Optional[Union[str, int]] = None,
         timeout: Optional[Union[str, int]] = None,
         schedule_id: Optional[str] = None,
+        flow_control: Optional[FlowControl] = None
     ) -> str:
         """
         Creates a schedule to send messages periodically, automatically serializing the
@@ -121,6 +127,8 @@ class AsyncScheduleApi:
             value permitted by the QStash plan. It is useful in scenarios, where a message
             should be delivered with a shorter timeout.
         :param schedule_id: Schedule id to use. Can be used to update the settings of an existing schedule.
+        :param flow_control: Settings for controlling the number of active requests and
+            number of requests per second with the same key.
         """
         return await self.create(
             destination=destination,
@@ -135,6 +143,7 @@ class AsyncScheduleApi:
             delay=delay,
             timeout=timeout,
             schedule_id=schedule_id,
+            flow_control=flow_control
         )
 
     async def get(self, schedule_id: str) -> Schedule:

--- a/qstash/dlq.py
+++ b/qstash/dlq.py
@@ -101,6 +101,9 @@ def parse_dlq_message_response(
         response_headers=response.get("responseHeader"),
         response_body=response.get("responseBody"),
         response_body_base64=response.get("responseBodyBase64"),
+        flow_control_key=response.get("flowControlKey"),
+        parallelism=response.get("parallelism"),
+        rate_per_second=response.get("ratePerSecond"),
     )
 
 

--- a/qstash/message.py
+++ b/qstash/message.py
@@ -631,6 +631,9 @@ def convert_to_batch_messages(
         if "timeout" in msg:
             batch_msg["timeout"] = msg["timeout"]
 
+        if "flow_control" in msg:
+            batch_msg["flow_control"] = msg["flow_control"]
+
         batch_messages.append(batch_msg)
 
     return batch_messages

--- a/qstash/message.py
+++ b/qstash/message.py
@@ -28,15 +28,14 @@ class LlmApi(TypedDict):
 ApiT = LlmApi  # In the future, this can be union of different API types
 
 
-@dataclasses.dataclass
-class FlowControl:
+class FlowControl(TypedDict, total=False):
     key: str
     """flow control key"""
 
-    parallelism: Optional[int] = None
+    parallelism: Optional[int]
     """number of requests which can be active with the same key"""
 
-    rate_per_second: Optional[int] = None
+    rate_per_second: Optional[int]
     """number of requests to activate per second with the same key"""
 
 
@@ -447,19 +446,19 @@ def prepare_headers(
         else:
             h["Upstash-Timeout"] = timeout
 
-    if flow_control and flow_control.key:
+    if flow_control and flow_control["key"]:
         control_values = []
-        if flow_control.parallelism is not None:
-            control_values.append(f"parallelism={flow_control.parallelism}")
-        if flow_control.rate_per_second is not None:
-            control_values.append(f"rate={flow_control.rate_per_second}")
+        if flow_control["parallelism"] is not None:
+            control_values.append(f"parallelism={flow_control["parallelism"]}")
+        if flow_control["rate_per_second"] is not None:
+            control_values.append(f"rate={flow_control["rate_per_second"]}")
 
         if not control_values:
             raise QStashError(
                 "Provide at least one of parallelism or rate_per_second for rate_limit"
             )
 
-        h["Upstash-Flow-Control-Key"] = flow_control.key
+        h["Upstash-Flow-Control-Key"] = flow_control["key"]
         h["Upstash-Flow-Control-Value"] = ", ".join(control_values)
 
     return h

--- a/qstash/message.py
+++ b/qstash/message.py
@@ -334,6 +334,15 @@ class Message:
     caller_ip: Optional[str]
     """IP address of the publisher of this message."""
 
+    flow_control_key: Optional[str]
+    """flow control key"""
+
+    parallelism: Optional[int]
+    """number of requests which can be active with the same flow control key"""
+
+    rate_per_second: Optional[int]
+    """number of requests to activate per second with the same flow control key"""
+
 
 def get_destination(
     *,
@@ -637,6 +646,9 @@ def parse_message_response(response: Dict[str, Any]) -> Message:
         failure_callback=response.get("failureCallback"),
         schedule_id=response.get("scheduleId"),
         caller_ip=response.get("callerIP"),
+        flow_control_key=response.get("flowControlKey"),
+        parallelism=response.get("parallelism"),
+        rate_per_second=response.get("rate"),
     )
 
 

--- a/qstash/message.py
+++ b/qstash/message.py
@@ -455,7 +455,7 @@ def prepare_headers(
 
         if not control_values:
             raise QStashError(
-                "Provide at least one of parallelism or rate_per_second for rate_limit"
+                "Provide at least one of parallelism or rate_per_second for flow_control"
             )
 
         h["Upstash-Flow-Control-Key"] = flow_control["key"]

--- a/qstash/message.py
+++ b/qstash/message.py
@@ -393,7 +393,7 @@ def prepare_headers(
     deduplication_id: Optional[str],
     content_based_deduplication: Optional[bool],
     timeout: Optional[Union[str, int]],
-    flow_control: Optional[FlowControl]
+    flow_control: Optional[FlowControl],
 ) -> Dict[str, str]:
     h = {}
 
@@ -448,7 +448,9 @@ def prepare_headers(
             control_values.append(f"rate={flow_control['rate_per_second']}")
 
         if not control_values:
-            raise QStashError("Provide at least one of parallelism or rate_per_second for rate_limit")
+            raise QStashError(
+                "Provide at least one of parallelism or rate_per_second for rate_limit"
+            )
 
         h["Upstash-Flow-Control-Key"] = flow_control["key"]
         h["Upstash-Flow-Control-Value"] = ", ".join(control_values)
@@ -524,7 +526,7 @@ def prepare_batch_message_body(messages: List[BatchRequest]) -> str:
             deduplication_id=msg.get("deduplication_id"),
             content_based_deduplication=msg.get("content_based_deduplication"),
             timeout=msg.get("timeout"),
-            flow_control=msg.get("flow_control")
+            flow_control=msg.get("flow_control"),
         )
 
         batch_messages.append(
@@ -674,7 +676,7 @@ class MessageApi:
         deduplication_id: Optional[str] = None,
         content_based_deduplication: Optional[bool] = None,
         timeout: Optional[Union[str, int]] = None,
-        flow_control: Optional[FlowControl] = None
+        flow_control: Optional[FlowControl] = None,
     ) -> Union[PublishResponse, List[PublishUrlGroupResponse]]:
         """
         Publishes a message to QStash.
@@ -735,7 +737,7 @@ class MessageApi:
             deduplication_id=deduplication_id,
             content_based_deduplication=content_based_deduplication,
             timeout=timeout,
-            flow_control=flow_control
+            flow_control=flow_control,
         )
 
         response = self._http.request(
@@ -764,7 +766,7 @@ class MessageApi:
         deduplication_id: Optional[str] = None,
         content_based_deduplication: Optional[bool] = None,
         timeout: Optional[Union[str, int]] = None,
-        flow_control: Optional[FlowControl] = None
+        flow_control: Optional[FlowControl] = None,
     ) -> Union[PublishResponse, List[PublishUrlGroupResponse]]:
         """
         Publish a message to QStash, automatically serializing the
@@ -822,7 +824,7 @@ class MessageApi:
             deduplication_id=deduplication_id,
             content_based_deduplication=content_based_deduplication,
             timeout=timeout,
-            flow_control=flow_control
+            flow_control=flow_control,
         )
 
     def enqueue(

--- a/qstash/message.py
+++ b/qstash/message.py
@@ -449,9 +449,9 @@ def prepare_headers(
     if flow_control and flow_control["key"]:
         control_values = []
         if flow_control["parallelism"] is not None:
-            control_values.append(f"parallelism={flow_control["parallelism"]}")
+            control_values.append(f"parallelism={flow_control['parallelism']}")
         if flow_control["rate_per_second"] is not None:
-            control_values.append(f"rate={flow_control["rate_per_second"]}")
+            control_values.append(f"rate={flow_control['rate_per_second']}")
 
         if not control_values:
             raise QStashError(

--- a/qstash/message.py
+++ b/qstash/message.py
@@ -446,11 +446,11 @@ def prepare_headers(
         else:
             h["Upstash-Timeout"] = timeout
 
-    if flow_control and flow_control["key"]:
+    if flow_control and "key" in flow_control:
         control_values = []
-        if flow_control["parallelism"] is not None:
+        if "parallelism" in flow_control:
             control_values.append(f"parallelism={flow_control['parallelism']}")
-        if flow_control["rate_per_second"] is not None:
+        if "rate_per_second" in flow_control:
             control_values.append(f"rate={flow_control['rate_per_second']}")
 
         if not control_values:

--- a/qstash/schedule.py
+++ b/qstash/schedule.py
@@ -77,7 +77,7 @@ def prepare_schedule_headers(
     delay: Optional[Union[str, int]],
     timeout: Optional[Union[str, int]],
     schedule_id: Optional[str],
-    flow_control: Optional[FlowControl]
+    flow_control: Optional[FlowControl],
 ) -> Dict[str, str]:
     h = {
         "Upstash-Cron": cron,
@@ -128,7 +128,9 @@ def prepare_schedule_headers(
             control_values.append(f"rate={flow_control['rate_per_second']}")
 
         if not control_values:
-            raise QStashError("Provide at least one of parallelism or rate_per_second for rate_limit")
+            raise QStashError(
+                "Provide at least one of parallelism or rate_per_second for rate_limit"
+            )
 
         h["Upstash-Flow-Control-Key"] = flow_control["key"]
         h["Upstash-Flow-Control-Value"] = ", ".join(control_values)
@@ -177,7 +179,7 @@ class ScheduleApi:
         delay: Optional[Union[str, int]] = None,
         timeout: Optional[Union[str, int]] = None,
         schedule_id: Optional[str] = None,
-        flow_control: Optional[FlowControl] = None
+        flow_control: Optional[FlowControl] = None,
     ) -> str:
         """
         Creates a schedule to send messages periodically.
@@ -219,7 +221,7 @@ class ScheduleApi:
             delay=delay,
             timeout=timeout,
             schedule_id=schedule_id,
-            flow_control=flow_control
+            flow_control=flow_control,
         )
 
         response = self._http.request(
@@ -245,7 +247,7 @@ class ScheduleApi:
         delay: Optional[Union[str, int]] = None,
         timeout: Optional[Union[str, int]] = None,
         schedule_id: Optional[str] = None,
-        flow_control: Optional[FlowControl] = None
+        flow_control: Optional[FlowControl] = None,
     ) -> str:
         """
         Creates a schedule to send messages periodically, automatically serializing the
@@ -290,7 +292,7 @@ class ScheduleApi:
             delay=delay,
             timeout=timeout,
             schedule_id=schedule_id,
-            flow_control=flow_control
+            flow_control=flow_control,
         )
 
     def get(self, schedule_id: str) -> Schedule:

--- a/qstash/schedule.py
+++ b/qstash/schedule.py
@@ -120,11 +120,11 @@ def prepare_schedule_headers(
     if schedule_id is not None:
         h["Upstash-Schedule-Id"] = schedule_id
 
-    if flow_control and flow_control["key"]:
+    if flow_control and "key" in flow_control:
         control_values = []
-        if flow_control["parallelism"] is not None:
+        if "parallelism" in flow_control:
             control_values.append(f"parallelism={flow_control['parallelism']}")
-        if flow_control["rate_per_second"] is not None:
+        if "rate_per_second" in flow_control:
             control_values.append(f"rate={flow_control['rate_per_second']}")
 
         if not control_values:

--- a/qstash/schedule.py
+++ b/qstash/schedule.py
@@ -120,19 +120,19 @@ def prepare_schedule_headers(
     if schedule_id is not None:
         h["Upstash-Schedule-Id"] = schedule_id
 
-    if flow_control and flow_control.get("key"):
+    if flow_control and flow_control.key:
         control_values = []
-        if flow_control.get("parallelism") is not None:
-            control_values.append(f"parallelism={flow_control['parallelism']}")
-        if flow_control.get("rate_per_second") is not None:
-            control_values.append(f"rate={flow_control['rate_per_second']}")
+        if flow_control.parallelism is not None:
+            control_values.append(f"parallelism={flow_control.parallelism}")
+        if flow_control.rate_per_second is not None:
+            control_values.append(f"rate={flow_control.rate_per_second}")
 
         if not control_values:
             raise QStashError(
                 "Provide at least one of parallelism or rate_per_second for rate_limit"
             )
 
-        h["Upstash-Flow-Control-Key"] = flow_control["key"]
+        h["Upstash-Flow-Control-Key"] = flow_control.key
         h["Upstash-Flow-Control-Value"] = ", ".join(control_values)
 
     return h

--- a/qstash/schedule.py
+++ b/qstash/schedule.py
@@ -129,7 +129,7 @@ def prepare_schedule_headers(
 
         if not control_values:
             raise QStashError(
-                "Provide at least one of parallelism or rate_per_second for rate_limit"
+                "Provide at least one of parallelism or rate_per_second for flow_control"
             )
 
         h["Upstash-Flow-Control-Key"] = flow_control["key"]

--- a/qstash/schedule.py
+++ b/qstash/schedule.py
@@ -123,9 +123,9 @@ def prepare_schedule_headers(
     if flow_control and flow_control["key"]:
         control_values = []
         if flow_control["parallelism"] is not None:
-            control_values.append(f"parallelism={flow_control["parallelism"]}")
+            control_values.append(f"parallelism={flow_control['parallelism']}")
         if flow_control["rate_per_second"] is not None:
-            control_values.append(f"rate={flow_control["rate_per_second"]}")
+            control_values.append(f"rate={flow_control['rate_per_second']}")
 
         if not control_values:
             raise QStashError(

--- a/qstash/schedule.py
+++ b/qstash/schedule.py
@@ -120,19 +120,19 @@ def prepare_schedule_headers(
     if schedule_id is not None:
         h["Upstash-Schedule-Id"] = schedule_id
 
-    if flow_control and flow_control.key:
+    if flow_control and flow_control["key"]:
         control_values = []
-        if flow_control.parallelism is not None:
-            control_values.append(f"parallelism={flow_control.parallelism}")
-        if flow_control.rate_per_second is not None:
-            control_values.append(f"rate={flow_control.rate_per_second}")
+        if flow_control["parallelism"] is not None:
+            control_values.append(f"parallelism={flow_control["parallelism"]}")
+        if flow_control["rate_per_second"] is not None:
+            control_values.append(f"rate={flow_control["rate_per_second"]}")
 
         if not control_values:
             raise QStashError(
                 "Provide at least one of parallelism or rate_per_second for rate_limit"
             )
 
-        h["Upstash-Flow-Control-Key"] = flow_control.key
+        h["Upstash-Flow-Control-Key"] = flow_control["key"]
         h["Upstash-Flow-Control-Value"] = ", ".join(control_values)
 
     return h

--- a/qstash/schedule.py
+++ b/qstash/schedule.py
@@ -55,6 +55,15 @@ class Schedule:
     paused: bool
     """Whether the schedule is paused or not."""
 
+    flow_control_key: Optional[str]
+    """flow control key"""
+
+    parallelism: Optional[int]
+    """number of requests which can be active with the same flow control key"""
+
+    rate_per_second: Optional[int]
+    """number of requests to activate per second with the same flow control key"""
+
 
 def prepare_schedule_headers(
     *,
@@ -143,6 +152,9 @@ def parse_schedule_response(response: Dict[str, Any]) -> Schedule:
         delay=response.get("delay"),
         caller_ip=response.get("callerIP"),
         paused=response.get("isPaused", False),
+        flow_control_key=response.get("flowControlKey"),
+        parallelism=response.get("parallelism"),
+        rate_per_second=response.get("rate"),
     )
 
 

--- a/tests/asyncio/test_message.py
+++ b/tests/asyncio/test_message.py
@@ -434,9 +434,10 @@ async def test_publish_with_flow_control_async(
     result = await async_client.message.publish_json(
         body={"ex_key": "ex_value"},
         url="https://httpstat.us/200",
-        flow_control={"key": "flow-key", "parallelism": "3", "rate_per_second": "4"},
+        flow_control=FlowControl(key="flow-key", parallelism=3, rate_per_second=4),
     )
 
+    assert isinstance(result, PublishResponse)
     message = await async_client.message.get(result.message_id)
 
     assert message.flow_control_key == "flow-key"
@@ -455,7 +456,7 @@ async def test_batch_with_flow_control_async(
                 url="https://httpstat.us/200",
                 flow_control=FlowControl(
                     key="flow-key-1",
-                    rate_per_second="1",
+                    rate_per_second=1,
                 ),
             ),
             BatchJsonRequest(
@@ -463,13 +464,15 @@ async def test_batch_with_flow_control_async(
                 url="https://httpstat.us/200",
                 flow_control=FlowControl(
                     key="flow-key-2",
-                    parallelism="5",
+                    parallelism=5,
                 ),
             ),
         ]
     )
 
+    assert isinstance(result[0], PublishResponse)
     message1 = await async_client.message.get(result[0].message_id)
+    assert isinstance(result[1], PublishResponse)
     message2 = await async_client.message.get(result[1].message_id)
 
     assert message1.flow_control_key == "flow-key-1"

--- a/tests/asyncio/test_message.py
+++ b/tests/asyncio/test_message.py
@@ -470,9 +470,9 @@ async def test_batch_with_flow_control_async(
         ]
     )
 
-    assert isinstance(result[0], PublishResponse)
+    assert isinstance(result[0], BatchResponse)
     message1 = await async_client.message.get(result[0].message_id)
-    assert isinstance(result[1], PublishResponse)
+    assert isinstance(result[1], BatchResponse)
     message2 = await async_client.message.get(result[1].message_id)
 
     assert message1.flow_control_key == "flow-key-1"

--- a/tests/asyncio/test_message.py
+++ b/tests/asyncio/test_message.py
@@ -12,7 +12,7 @@ from qstash.message import (
     BatchResponse,
     EnqueueResponse,
     PublishResponse,
-    FlowControl
+    FlowControl,
 )
 from tests import assert_eventually_async, OPENAI_API_KEY
 
@@ -434,11 +434,7 @@ async def test_publish_with_flow_control_async(
     result = await async_client.message.publish_json(
         body={"ex_key": "ex_value"},
         url="https://httpstat.us/200",
-        flow_control={
-            "key": "flow-key",
-            "parallelism": "3",
-            "rate_per_second": "4"
-        },
+        flow_control={"key": "flow-key", "parallelism": "3", "rate_per_second": "4"},
     )
 
     message = await async_client.message.get(result.message_id)

--- a/tests/asyncio/test_message.py
+++ b/tests/asyncio/test_message.py
@@ -443,9 +443,9 @@ async def test_publish_with_flow_control_async(
 
     message = await async_client.message.get(result.message_id)
 
-    assert message.flow_control_key is "flow-key"
-    assert message.parallelism is 3
-    assert message.rate_per_second is 4
+    assert message.flow_control_key == "flow-key"
+    assert message.parallelism == 3
+    assert message.rate_per_second == 4
 
 
 @pytest.mark.asyncio
@@ -476,10 +476,10 @@ async def test_batch_with_flow_control_async(
     message1 = await async_client.message.get(result[0].message_id)
     message2 = await async_client.message.get(result[1].message_id)
 
-    assert message1.flow_control_key is "flow-key-1"
+    assert message1.flow_control_key == "flow-key-1"
     assert message1.parallelism is None
-    assert message1.rate_per_second is 1
+    assert message1.rate_per_second == 1
 
-    assert message2.flow_control_key is "flow-key-2"
-    assert message2.parallelism is 5
+    assert message2.flow_control_key == "flow-key-2"
+    assert message2.parallelism == 5
     assert message2.rate_per_second is None

--- a/tests/asyncio/test_message.py
+++ b/tests/asyncio/test_message.py
@@ -433,7 +433,7 @@ async def test_publish_with_flow_control_async(
 ) -> None:
     result = await async_client.message.publish_json(
         body={"ex_key": "ex_value"},
-        url="https://httpstat.us/200",
+        url="https://httpstat.us/200?sleep=30000",
         flow_control=FlowControl(key="flow-key", parallelism=3, rate_per_second=4),
     )
 

--- a/tests/asyncio/test_message.py
+++ b/tests/asyncio/test_message.py
@@ -424,3 +424,53 @@ async def test_enqueue_api_llm_custom_provider_async(
     assert isinstance(res, EnqueueResponse)
 
     assert len(res.message_id) > 0
+
+
+@pytest.mark.asyncio
+async def test_publish_with_flow_control_async(
+    async_client: AsyncQStash,
+) -> None:
+    result = await async_client.message.publish_json(
+        body={"ex_key": "ex_value"},
+        url="https://httpstat.us/200",
+        flow_control={
+            "key": "flow-key",
+            "parallelism": "3",
+            "rate_per_second": "4"
+        },
+    )
+
+    message = await async_client.message.get(result.message_id)
+
+    # TODO assert flow control settings of message
+
+
+@pytest.mark.asyncio
+async def test_batch_with_flow_control_async(
+    async_client: AsyncQStash,
+) -> None:
+    result = await async_client.message.batch_json(
+        [
+            {
+                "body": {"ex_key": "ex_value"},
+                "url": "https://httpstat.us/200",
+                "flow_control": {
+                    "key": "flow-key",
+                    "rate_per_second": "1"
+                }
+            },
+            {
+                "body": {"ex_key": "ex_value"},
+                "url": "https://httpstat.us/200",
+                "flow_control": {
+                    "key": "flow-key",
+                    "parallelism": "5",
+                }
+            }
+        ]
+    )
+
+    message1 = await async_client.message.get(result[0].message_id)
+    message2 = await async_client.message.get(result[1].message_id)
+
+    # TODO assert flow control settings of message

--- a/tests/asyncio/test_message.py
+++ b/tests/asyncio/test_message.py
@@ -453,7 +453,7 @@ async def test_batch_with_flow_control_async(
         [
             BatchJsonRequest(
                 body={"ex_key": "ex_value"},
-                url="https://httpstat.us/200",
+                url="https://httpstat.us/200?sleep=30000",
                 flow_control=FlowControl(
                     key="flow-key-1",
                     rate_per_second=1,
@@ -461,7 +461,7 @@ async def test_batch_with_flow_control_async(
             ),
             BatchJsonRequest(
                 body={"ex_key": "ex_value"},
-                url="https://httpstat.us/200",
+                url="https://httpstat.us/200?sleep=30000",
                 flow_control=FlowControl(
                     key="flow-key-2",
                     parallelism=5,

--- a/tests/asyncio/test_schedules.py
+++ b/tests/asyncio/test_schedules.py
@@ -81,6 +81,8 @@ async def test_schedule_with_flow_control_async(
 
     schedule = await async_client.schedule.get(schedule_id)
 
-    # TODO: Add assertions
+    assert schedule.flow_control_key is "flow-key"
+    assert schedule.parallelism is 2
+    assert schedule.rate_per_second is None
 
     await cleanup_schedule_async(async_client, schedule_id)

--- a/tests/asyncio/test_schedules.py
+++ b/tests/asyncio/test_schedules.py
@@ -62,3 +62,25 @@ async def test_schedule_pause_resume_async(
 
     res = await async_client.schedule.get(schedule_id)
     assert res.paused is False
+
+async def test_schedule_with_flow_control_async(
+    async_client: AsyncQStash,
+    cleanup_schedule_async: Callable[[AsyncQStash, str], None],
+    ) -> None:
+
+    schedule_id = await async_client.schedule.create_json(
+        cron="1 1 1 1 1",
+        destination="https://httpstat.us/200",
+        body={"ex_key": "ex_value"},
+        flow_control={
+            "key": "flow-key",
+            "parallelism": 2
+        }
+    )
+
+
+    schedule = await async_client.schedule.get(schedule_id)
+
+    # TODO: Add assertions
+
+    await cleanup_schedule_async(async_client, schedule_id)

--- a/tests/asyncio/test_schedules.py
+++ b/tests/asyncio/test_schedules.py
@@ -3,6 +3,7 @@ from typing import Callable
 import pytest
 
 from qstash import AsyncQStash
+from qstash.message import FlowControl
 
 
 @pytest.mark.asyncio
@@ -72,7 +73,7 @@ async def test_schedule_with_flow_control_async(
         cron="1 1 1 1 1",
         destination="https://httpstat.us/200",
         body={"ex_key": "ex_value"},
-        flow_control={"key": "flow-key", "parallelism": 2},
+        flow_control=FlowControl(key="flow-key", parallelism=2),
     )
 
     schedule = await async_client.schedule.get(schedule_id)
@@ -81,4 +82,4 @@ async def test_schedule_with_flow_control_async(
     assert schedule.parallelism == 2
     assert schedule.rate_per_second is None
 
-    await cleanup_schedule_async(async_client, schedule_id)
+    await async_client.schedule.delete(schedule_id)

--- a/tests/asyncio/test_schedules.py
+++ b/tests/asyncio/test_schedules.py
@@ -82,4 +82,4 @@ async def test_schedule_with_flow_control_async(
     assert schedule.parallelism == 2
     assert schedule.rate_per_second is None
 
-    await async_client.schedule.delete(schedule_id)
+    cleanup_schedule_async(async_client, schedule_id)

--- a/tests/asyncio/test_schedules.py
+++ b/tests/asyncio/test_schedules.py
@@ -75,6 +75,7 @@ async def test_schedule_with_flow_control_async(
         body={"ex_key": "ex_value"},
         flow_control=FlowControl(key="flow-key", parallelism=2),
     )
+    cleanup_schedule_async(async_client, schedule_id)
 
     schedule = await async_client.schedule.get(schedule_id)
 
@@ -82,4 +83,3 @@ async def test_schedule_with_flow_control_async(
     assert schedule.parallelism == 2
     assert schedule.rate_per_second is None
 
-    cleanup_schedule_async(async_client, schedule_id)

--- a/tests/asyncio/test_schedules.py
+++ b/tests/asyncio/test_schedules.py
@@ -63,21 +63,17 @@ async def test_schedule_pause_resume_async(
     res = await async_client.schedule.get(schedule_id)
     assert res.paused is False
 
+
 async def test_schedule_with_flow_control_async(
     async_client: AsyncQStash,
     cleanup_schedule_async: Callable[[AsyncQStash, str], None],
-    ) -> None:
-
+) -> None:
     schedule_id = await async_client.schedule.create_json(
         cron="1 1 1 1 1",
         destination="https://httpstat.us/200",
         body={"ex_key": "ex_value"},
-        flow_control={
-            "key": "flow-key",
-            "parallelism": 2
-        }
+        flow_control={"key": "flow-key", "parallelism": 2},
     )
-
 
     schedule = await async_client.schedule.get(schedule_id)
 

--- a/tests/asyncio/test_schedules.py
+++ b/tests/asyncio/test_schedules.py
@@ -81,8 +81,8 @@ async def test_schedule_with_flow_control_async(
 
     schedule = await async_client.schedule.get(schedule_id)
 
-    assert schedule.flow_control_key is "flow-key"
-    assert schedule.parallelism is 2
+    assert schedule.flow_control_key == "flow-key"
+    assert schedule.parallelism == 2
     assert schedule.rate_per_second is None
 
     await cleanup_schedule_async(async_client, schedule_id)

--- a/tests/asyncio/test_schedules.py
+++ b/tests/asyncio/test_schedules.py
@@ -82,4 +82,3 @@ async def test_schedule_with_flow_control_async(
     assert schedule.flow_control_key == "flow-key"
     assert schedule.parallelism == 2
     assert schedule.rate_per_second is None
-

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -400,3 +400,51 @@ def test_enqueue_api_llm_custom_provider(
     assert isinstance(res, EnqueueResponse)
 
     assert len(res.message_id) > 0
+
+
+def test_publish_with_flow_control(
+    client: QStash,
+) -> None:
+    result = client.message.publish_json(
+        body={"ex_key": "ex_value"},
+        url="https://httpstat.us/200",
+        flow_control={
+            "key": "flow-key",
+            "parallelism": "3",
+            "rate_per_second": "4"
+        },
+    )
+
+    message = client.message.get(result.message_id)
+
+    # TODO assert flow control settings of message
+
+
+def test_batch_with_flow_control(
+    client: QStash
+) -> None:
+    result = client.message.batch_json(
+        [
+            {
+                "body": {"ex_key": "ex_value"},
+                "url": "https://httpstat.us/200",
+                "flow_control": {
+                    "key": "flow-key",
+                    "rate_per_second": "1"
+                }
+            },
+            {
+                "body": {"ex_key": "ex_value"},
+                "url": "https://httpstat.us/200",
+                "flow_control": {
+                    "key": "flow-key",
+                    "parallelism": "5",
+                }
+            }
+        ]
+    )
+
+    message1 = client.message.get(result[0].message_id)
+    message2 = client.message.get(result[1].message_id)
+
+    # TODO assert flow control settings of message

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -408,11 +408,7 @@ def test_publish_with_flow_control(
     result = client.message.publish_json(
         body={"ex_key": "ex_value"},
         url="https://httpstat.us/200",
-        flow_control={
-            "key": "flow-key",
-            "parallelism": "3",
-            "rate_per_second": "4"
-        },
+        flow_control={"key": "flow-key", "parallelism": "3", "rate_per_second": "4"},
     )
 
     message = client.message.get(result.message_id)
@@ -421,18 +417,14 @@ def test_publish_with_flow_control(
     assert message.parallelism == 3
     assert message.rate_per_second == 4
 
-def test_batch_with_flow_control(
-    client: QStash
-) -> None:
+
+def test_batch_with_flow_control(client: QStash) -> None:
     result = client.message.batch_json(
         [
             {
                 "body": {"ex_key": "ex_value"},
                 "url": "https://httpstat.us/200",
-                "flow_control": {
-                    "key": "flow-key-1",
-                    "rate_per_second": "1"
-                }
+                "flow_control": {"key": "flow-key-1", "rate_per_second": "1"},
             },
             {
                 "body": {"ex_key": "ex_value"},
@@ -440,8 +432,8 @@ def test_batch_with_flow_control(
                 "flow_control": {
                     "key": "flow-key-2",
                     "parallelism": "5",
-                }
-            }
+                },
+            },
         ]
     )
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -417,9 +417,9 @@ def test_publish_with_flow_control(
 
     message = client.message.get(result.message_id)
 
-    assert message.flow_control_key is "flow-key"
-    assert message.parallelism is 3
-    assert message.rate_per_second is 4
+    assert message.flow_control_key == "flow-key"
+    assert message.parallelism == 3
+    assert message.rate_per_second == 4
 
 def test_batch_with_flow_control(
     client: QStash
@@ -448,10 +448,10 @@ def test_batch_with_flow_control(
     message1 = client.message.get(result[0].message_id)
     message2 = client.message.get(result[1].message_id)
 
-    assert message1.flow_control_key is "flow-key-1"
+    assert message1.flow_control_key == "flow-key-1"
     assert message1.parallelism is None
-    assert message1.rate_per_second is 1
+    assert message1.rate_per_second == 1
 
-    assert message2.flow_control_key is "flow-key-2"
-    assert message2.parallelism is 5
+    assert message2.flow_control_key == "flow-key-2"
+    assert message2.parallelism == 5
     assert message2.rate_per_second is None

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -417,8 +417,9 @@ def test_publish_with_flow_control(
 
     message = client.message.get(result.message_id)
 
-    # TODO assert flow control settings of message
-
+    assert message.flow_control_key is "flow-key"
+    assert message.parallelism is 3
+    assert message.rate_per_second is 4
 
 def test_batch_with_flow_control(
     client: QStash
@@ -429,7 +430,7 @@ def test_batch_with_flow_control(
                 "body": {"ex_key": "ex_value"},
                 "url": "https://httpstat.us/200",
                 "flow_control": {
-                    "key": "flow-key",
+                    "key": "flow-key-1",
                     "rate_per_second": "1"
                 }
             },
@@ -437,7 +438,7 @@ def test_batch_with_flow_control(
                 "body": {"ex_key": "ex_value"},
                 "url": "https://httpstat.us/200",
                 "flow_control": {
-                    "key": "flow-key",
+                    "key": "flow-key-2",
                     "parallelism": "5",
                 }
             }
@@ -447,4 +448,10 @@ def test_batch_with_flow_control(
     message1 = client.message.get(result[0].message_id)
     message2 = client.message.get(result[1].message_id)
 
-    # TODO assert flow control settings of message
+    assert message1.flow_control_key is "flow-key-1"
+    assert message1.parallelism is None
+    assert message1.rate_per_second is 1
+
+    assert message2.flow_control_key is "flow-key-2"
+    assert message2.parallelism is 5
+    assert message2.rate_per_second is None

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -408,7 +408,7 @@ def test_publish_with_flow_control(
 ) -> None:
     result = client.message.publish_json(
         body={"ex_key": "ex_value"},
-        url="https://httpstat.us/200",
+        url="https://httpstat.us/200?sleep=30000",
         flow_control=FlowControl(key="flow-key", parallelism=3, rate_per_second=4),
     )
 
@@ -425,12 +425,12 @@ def test_batch_with_flow_control(client: QStash) -> None:
         [
             {
                 "body": {"ex_key": "ex_value"},
-                "url": "https://httpstat.us/200",
+                "url": "https://httpstat.us/200?sleep=30000",
                 "flow_control": FlowControl(key="flow-key-1", rate_per_second=1),
             },
             {
                 "body": {"ex_key": "ex_value"},
-                "url": "https://httpstat.us/200",
+                "url": "https://httpstat.us/200?sleep=30000",
                 "flow_control": FlowControl(key="flow-key-2", parallelism=5),
             },
         ]

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -436,9 +436,9 @@ def test_batch_with_flow_control(client: QStash) -> None:
         ]
     )
 
-    assert isinstance(result[0], PublishResponse)
+    assert isinstance(result[0], BatchResponse)
     message1 = client.message.get(result[0].message_id)
-    assert isinstance(result[1], PublishResponse)
+    assert isinstance(result[1], BatchResponse)
     message2 = client.message.get(result[1].message_id)
 
     assert message1.flow_control_key == "flow-key-1"

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -79,3 +79,21 @@ def test_schedule_pause_resume(
 
     res = client.schedule.get(schedule_id)
     assert res.paused is False
+
+def test_schedule_with_flow_control(client: QStash, cleanup_schedule: Callable[[QStash, str], None]) -> None:
+
+    schedule_id = client.schedule.create_json(
+        cron="1 1 1 1 1",
+        destination="https://httpstat.us/200",
+        body={"ex_key": "ex_value"},
+        flow_control={
+            "key": "flow-key",
+            "parallelism": 2
+        }
+    )
+
+    schedule = client.schedule.get(schedule_id)
+
+    # TODO: Add assertions
+
+    cleanup_schedule(client, schedule_id)

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -98,4 +98,3 @@ def test_schedule_with_flow_control(
     assert schedule.flow_control_key == "flow-key"
     assert schedule.parallelism == 2
     assert schedule.rate_per_second is None
-

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -94,8 +94,8 @@ def test_schedule_with_flow_control(client: QStash, cleanup_schedule: Callable[[
 
     schedule = client.schedule.get(schedule_id)
 
-    assert schedule.flow_control_key is "flow-key"
-    assert schedule.parallelism is 2
+    assert schedule.flow_control_key == "flow-key"
+    assert schedule.parallelism == 2
     assert schedule.rate_per_second is None
 
     cleanup_schedule(client, schedule_id)

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1,4 +1,5 @@
 from typing import Callable
+from qstash.message import FlowControl
 
 import pytest
 
@@ -88,7 +89,7 @@ def test_schedule_with_flow_control(
         cron="1 1 1 1 1",
         destination="https://httpstat.us/200",
         body={"ex_key": "ex_value"},
-        flow_control={"key": "flow-key", "parallelism": 2},
+        flow_control=FlowControl(key="flow-key", parallelism=2),
     )
 
     schedule = client.schedule.get(schedule_id)

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -80,16 +80,15 @@ def test_schedule_pause_resume(
     res = client.schedule.get(schedule_id)
     assert res.paused is False
 
-def test_schedule_with_flow_control(client: QStash, cleanup_schedule: Callable[[QStash, str], None]) -> None:
 
+def test_schedule_with_flow_control(
+    client: QStash, cleanup_schedule: Callable[[QStash, str], None]
+) -> None:
     schedule_id = client.schedule.create_json(
         cron="1 1 1 1 1",
         destination="https://httpstat.us/200",
         body={"ex_key": "ex_value"},
-        flow_control={
-            "key": "flow-key",
-            "parallelism": 2
-        }
+        flow_control={"key": "flow-key", "parallelism": 2},
     )
 
     schedule = client.schedule.get(schedule_id)

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -94,6 +94,8 @@ def test_schedule_with_flow_control(client: QStash, cleanup_schedule: Callable[[
 
     schedule = client.schedule.get(schedule_id)
 
-    # TODO: Add assertions
+    assert schedule.flow_control_key is "flow-key"
+    assert schedule.parallelism is 2
+    assert schedule.rate_per_second is None
 
     cleanup_schedule(client, schedule_id)

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -91,6 +91,7 @@ def test_schedule_with_flow_control(
         body={"ex_key": "ex_value"},
         flow_control=FlowControl(key="flow-key", parallelism=2),
     )
+    cleanup_schedule(client, schedule_id)
 
     schedule = client.schedule.get(schedule_id)
 
@@ -98,4 +99,3 @@ def test_schedule_with_flow_control(
     assert schedule.parallelism == 2
     assert schedule.rate_per_second is None
 
-    cleanup_schedule(client, schedule_id)


### PR DESCRIPTION
This PR adds the following parameters which allow controlling the message per second and parallelism:
```
client.message.publish_json(
    body={"ex_key": "ex_value"},
    url="https://httpstat.us/200",
    flow_control={
        "key": "flow-key",
        "parallelism": "3",
        "rate_per_second": "4"
    },
)
```

`flow_control` is available for publish, batch and schedules. It's not available for queues.

Equivalent of https://github.com/upstash/qstash-js/pull/223