### PR TITLE
Bump version to 2.0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qstash"
-version = "2.0.3"
+version = "2.0.5"
 description = "Python SDK for Upstash QStash"
 license = "MIT"
 authors = ["Upstash <support@upstash.com>"]

--- a/qstash/__init__.py
+++ b/qstash/__init__.py
@@ -2,5 +2,5 @@ from qstash.asyncio.client import AsyncQStash
 from qstash.client import QStash
 from qstash.receiver import Receiver
 
-__version__ = "2.0.3"
+__version__ = "2.0.5"
 __all__ = ["QStash", "AsyncQStash", "Receiver"]


### PR DESCRIPTION
Bumping version to 2.0.5.

Before this, released 2.0.4 at d7d24787900bccee90825e5503c73fc2f4257916 with https://github.com/upstash/qstash-py/pull/35.

Next we will release https://github.com/upstash/qstash-py/pull/36 as 2.0.5 when we are ready.