### PR TITLE
DX-2495: add flow control pause, resume, pin, unpin, and resetRate endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qstash"
-version = "3.2.0"
+version = "3.1.0"
 description = "Python SDK for Upstash QStash"
 license = "MIT"
 authors = ["Upstash <support@upstash.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qstash"
-version = "3.1.0"
+version = "3.3.0"
 description = "Python SDK for Upstash QStash"
 license = "MIT"
 authors = ["Upstash <support@upstash.com>"]

--- a/qstash/__init__.py
+++ b/qstash/__init__.py
@@ -2,5 +2,5 @@ from qstash.asyncio.client import AsyncQStash
 from qstash.client import QStash
 from qstash.receiver import Receiver
 
-__version__ = "3.2.0"
+__version__ = "3.1.0"
 __all__ = ["QStash", "AsyncQStash", "Receiver"]

--- a/qstash/__init__.py
+++ b/qstash/__init__.py
@@ -2,5 +2,5 @@ from qstash.asyncio.client import AsyncQStash
 from qstash.client import QStash
 from qstash.receiver import Receiver
 
-__version__ = "3.1.0"
+__version__ = "3.3.0"
 __all__ = ["QStash", "AsyncQStash", "Receiver"]

--- a/qstash/asyncio/flow_control.py
+++ b/qstash/asyncio/flow_control.py
@@ -82,12 +82,12 @@ class AsyncFlowControlApi:
         """
         params: Dict[str, str] = {}
         if options is not None:
-            if options.parallelism is not None:
-                params["parallelism"] = str(options.parallelism)
-            if options.rate is not None:
-                params["rate"] = str(options.rate)
-            if options.period is not None:
-                params["period"] = str(options.period)
+            if "parallelism" in options:
+                params["parallelism"] = str(options["parallelism"])
+            if "rate" in options:
+                params["rate"] = str(options["rate"])
+            if "period" in options:
+                params["period"] = str(options["period"])
 
         await self._http.request(
             path=f"/v2/flowControl/{flow_control_key}/pin",
@@ -110,10 +110,10 @@ class AsyncFlowControlApi:
         """
         params: Dict[str, str] = {}
         if options is not None:
-            if options.parallelism is not None:
-                params["parallelism"] = str(options.parallelism).lower()
-            if options.rate is not None:
-                params["rate"] = str(options.rate).lower()
+            if "parallelism" in options:
+                params["parallelism"] = str(options["parallelism"]).lower()
+            if "rate" in options:
+                params["rate"] = str(options["rate"]).lower()
 
         await self._http.request(
             path=f"/v2/flowControl/{flow_control_key}/unpin",

--- a/qstash/asyncio/flow_control.py
+++ b/qstash/asyncio/flow_control.py
@@ -68,9 +68,7 @@ class AsyncFlowControlApi:
             parse_response=False,
         )
 
-    async def pin(
-        self, flow_control_key: str, options: PinFlowControlOptions
-    ) -> None:
+    async def pin(self, flow_control_key: str, options: PinFlowControlOptions) -> None:
         """
         Pin a processing configuration for a flow-control key.
 

--- a/qstash/asyncio/flow_control.py
+++ b/qstash/asyncio/flow_control.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict
 
 from qstash.asyncio.http import AsyncHttpClient
 from qstash.flow_control_api import (
@@ -69,7 +69,7 @@ class AsyncFlowControlApi:
         )
 
     async def pin(
-        self, flow_control_key: str, options: Optional[PinFlowControlOptions] = None
+        self, flow_control_key: str, options: PinFlowControlOptions
     ) -> None:
         """
         Pin a processing configuration for a flow-control key.
@@ -81,13 +81,12 @@ class AsyncFlowControlApi:
         :param options: The configuration to pin.
         """
         params: Dict[str, str] = {}
-        if options is not None:
-            if "parallelism" in options:
-                params["parallelism"] = str(options["parallelism"])
-            if "rate" in options:
-                params["rate"] = str(options["rate"])
-            if "period" in options:
-                params["period"] = str(options["period"])
+        if "parallelism" in options:
+            params["parallelism"] = str(options["parallelism"])
+        if "rate" in options:
+            params["rate"] = str(options["rate"])
+        if "period" in options:
+            params["period"] = str(options["period"])
 
         await self._http.request(
             path=f"/v2/flowControl/{flow_control_key}/pin",
@@ -97,7 +96,7 @@ class AsyncFlowControlApi:
         )
 
     async def unpin(
-        self, flow_control_key: str, options: Optional[UnpinFlowControlOptions] = None
+        self, flow_control_key: str, options: UnpinFlowControlOptions
     ) -> None:
         """
         Remove the pinned configuration for a flow-control key.
@@ -109,11 +108,10 @@ class AsyncFlowControlApi:
         :param options: Which configurations to unpin.
         """
         params: Dict[str, str] = {}
-        if options is not None:
-            if "parallelism" in options:
-                params["parallelism"] = str(options["parallelism"]).lower()
-            if "rate" in options:
-                params["rate"] = str(options["rate"]).lower()
+        if "parallelism" in options:
+            params["parallelism"] = str(options["parallelism"]).lower()
+        if "rate" in options:
+            params["rate"] = str(options["rate"]).lower()
 
         await self._http.request(
             path=f"/v2/flowControl/{flow_control_key}/unpin",

--- a/qstash/asyncio/flow_control.py
+++ b/qstash/asyncio/flow_control.py
@@ -1,7 +1,11 @@
+from typing import Dict, Optional
+
 from qstash.asyncio.http import AsyncHttpClient
 from qstash.flow_control_api import (
     FlowControlInfo,
     GlobalParallelismInfo,
+    PinFlowControlOptions,
+    UnpinFlowControlOptions,
     parse_flow_control_info,
 )
 
@@ -35,4 +39,100 @@ class AsyncFlowControlApi:
         return GlobalParallelismInfo(
             parallelism_max=response.get("parallelismMax", 0),
             parallelism_count=response.get("parallelismCount", 0),
+        )
+
+    async def pause(self, flow_control_key: str) -> None:
+        """
+        Pause message delivery for a flow-control key.
+
+        Messages already in the waitlist will remain there.
+        New incoming messages will be added directly to the waitlist.
+
+        :param flow_control_key: The flow control key to pause.
+        """
+        await self._http.request(
+            path=f"/v2/flowControl/{flow_control_key}/pause",
+            method="POST",
+            parse_response=False,
+        )
+
+    async def resume(self, flow_control_key: str) -> None:
+        """
+        Resume message delivery for a flow-control key.
+
+        :param flow_control_key: The flow control key to resume.
+        """
+        await self._http.request(
+            path=f"/v2/flowControl/{flow_control_key}/resume",
+            method="POST",
+            parse_response=False,
+        )
+
+    async def pin(
+        self, flow_control_key: str, options: Optional[PinFlowControlOptions] = None
+    ) -> None:
+        """
+        Pin a processing configuration for a flow-control key.
+
+        While pinned, the system ignores configurations provided by incoming
+        messages and uses the pinned configuration instead.
+
+        :param flow_control_key: The flow control key to pin.
+        :param options: The configuration to pin.
+        """
+        params: Dict[str, str] = {}
+        if options is not None:
+            if options.parallelism is not None:
+                params["parallelism"] = str(options.parallelism)
+            if options.rate is not None:
+                params["rate"] = str(options.rate)
+            if options.period is not None:
+                params["period"] = str(options.period)
+
+        await self._http.request(
+            path=f"/v2/flowControl/{flow_control_key}/pin",
+            method="POST",
+            params=params or None,
+            parse_response=False,
+        )
+
+    async def unpin(
+        self, flow_control_key: str, options: Optional[UnpinFlowControlOptions] = None
+    ) -> None:
+        """
+        Remove the pinned configuration for a flow-control key.
+
+        After unpinning, the system resumes updating the configuration
+        based on incoming messages.
+
+        :param flow_control_key: The flow control key to unpin.
+        :param options: Which configurations to unpin.
+        """
+        params: Dict[str, str] = {}
+        if options is not None:
+            if options.parallelism is not None:
+                params["parallelism"] = str(options.parallelism).lower()
+            if options.rate is not None:
+                params["rate"] = str(options.rate).lower()
+
+        await self._http.request(
+            path=f"/v2/flowControl/{flow_control_key}/unpin",
+            method="POST",
+            params=params or None,
+            parse_response=False,
+        )
+
+    async def reset_rate(self, flow_control_key: str) -> None:
+        """
+        Reset the rate configuration state for a flow-control key.
+
+        Clears the current rate count and immediately ends the current period.
+        The current timestamp becomes the start of the new rate period.
+
+        :param flow_control_key: The flow control key to reset rate for.
+        """
+        await self._http.request(
+            path=f"/v2/flowControl/{flow_control_key}/resetRate",
+            method="POST",
+            parse_response=False,
         )

--- a/qstash/flow_control_api.py
+++ b/qstash/flow_control_api.py
@@ -150,9 +150,7 @@ class FlowControlApi:
             parse_response=False,
         )
 
-    def pin(
-        self, flow_control_key: str, options: PinFlowControlOptions
-    ) -> None:
+    def pin(self, flow_control_key: str, options: PinFlowControlOptions) -> None:
         """
         Pin a processing configuration for a flow-control key.
 
@@ -177,9 +175,7 @@ class FlowControlApi:
             parse_response=False,
         )
 
-    def unpin(
-        self, flow_control_key: str, options: UnpinFlowControlOptions
-    ) -> None:
+    def unpin(self, flow_control_key: str, options: UnpinFlowControlOptions) -> None:
         """
         Remove the pinned configuration for a flow-control key.
 

--- a/qstash/flow_control_api.py
+++ b/qstash/flow_control_api.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, TypedDict
 
 from qstash.http import HttpClient
 
@@ -53,28 +53,26 @@ class GlobalParallelismInfo:
     """The current number of active requests globally."""
 
 
-@dataclasses.dataclass
-class PinFlowControlOptions:
+class PinFlowControlOptions(TypedDict, total=False):
     """Options for pinning a flow control key configuration."""
 
-    parallelism: Optional[int] = None
+    parallelism: int
     """The parallelism value to apply to the flow-control key."""
 
-    rate: Optional[int] = None
+    rate: int
     """The rate value to apply to the flow-control key."""
 
-    period: Optional[int] = None
+    period: int
     """The period value to apply to the flow-control key, in seconds."""
 
 
-@dataclasses.dataclass
-class UnpinFlowControlOptions:
+class UnpinFlowControlOptions(TypedDict, total=False):
     """Options for unpinning a flow control key configuration."""
 
-    parallelism: Optional[bool] = None
+    parallelism: bool
     """Whether to unpin the parallelism configuration."""
 
-    rate: Optional[bool] = None
+    rate: bool
     """Whether to unpin the rate configuration."""
 
 
@@ -166,12 +164,12 @@ class FlowControlApi:
         """
         params: Dict[str, str] = {}
         if options is not None:
-            if options.parallelism is not None:
-                params["parallelism"] = str(options.parallelism)
-            if options.rate is not None:
-                params["rate"] = str(options.rate)
-            if options.period is not None:
-                params["period"] = str(options.period)
+            if "parallelism" in options:
+                params["parallelism"] = str(options["parallelism"])
+            if "rate" in options:
+                params["rate"] = str(options["rate"])
+            if "period" in options:
+                params["period"] = str(options["period"])
 
         self._http.request(
             path=f"/v2/flowControl/{flow_control_key}/pin",
@@ -194,10 +192,10 @@ class FlowControlApi:
         """
         params: Dict[str, str] = {}
         if options is not None:
-            if options.parallelism is not None:
-                params["parallelism"] = str(options.parallelism).lower()
-            if options.rate is not None:
-                params["rate"] = str(options.rate).lower()
+            if "parallelism" in options:
+                params["parallelism"] = str(options["parallelism"]).lower()
+            if "rate" in options:
+                params["rate"] = str(options["rate"]).lower()
 
         self._http.request(
             path=f"/v2/flowControl/{flow_control_key}/unpin",

--- a/qstash/flow_control_api.py
+++ b/qstash/flow_control_api.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Dict, Optional, TypedDict
+from typing import Any, Dict, TypedDict
 
 from qstash.http import HttpClient
 
@@ -151,7 +151,7 @@ class FlowControlApi:
         )
 
     def pin(
-        self, flow_control_key: str, options: Optional[PinFlowControlOptions] = None
+        self, flow_control_key: str, options: PinFlowControlOptions
     ) -> None:
         """
         Pin a processing configuration for a flow-control key.
@@ -163,13 +163,12 @@ class FlowControlApi:
         :param options: The configuration to pin.
         """
         params: Dict[str, str] = {}
-        if options is not None:
-            if "parallelism" in options:
-                params["parallelism"] = str(options["parallelism"])
-            if "rate" in options:
-                params["rate"] = str(options["rate"])
-            if "period" in options:
-                params["period"] = str(options["period"])
+        if "parallelism" in options:
+            params["parallelism"] = str(options["parallelism"])
+        if "rate" in options:
+            params["rate"] = str(options["rate"])
+        if "period" in options:
+            params["period"] = str(options["period"])
 
         self._http.request(
             path=f"/v2/flowControl/{flow_control_key}/pin",
@@ -179,7 +178,7 @@ class FlowControlApi:
         )
 
     def unpin(
-        self, flow_control_key: str, options: Optional[UnpinFlowControlOptions] = None
+        self, flow_control_key: str, options: UnpinFlowControlOptions
     ) -> None:
         """
         Remove the pinned configuration for a flow-control key.
@@ -191,11 +190,10 @@ class FlowControlApi:
         :param options: Which configurations to unpin.
         """
         params: Dict[str, str] = {}
-        if options is not None:
-            if "parallelism" in options:
-                params["parallelism"] = str(options["parallelism"]).lower()
-            if "rate" in options:
-                params["rate"] = str(options["rate"]).lower()
+        if "parallelism" in options:
+            params["parallelism"] = str(options["parallelism"]).lower()
+        if "rate" in options:
+            params["rate"] = str(options["rate"]).lower()
 
         self._http.request(
             path=f"/v2/flowControl/{flow_control_key}/unpin",

--- a/qstash/flow_control_api.py
+++ b/qstash/flow_control_api.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from qstash.http import HttpClient
 
@@ -32,6 +32,15 @@ class FlowControlInfo:
     rate_period_start: int
     """The start time of the current rate period as a unix timestamp."""
 
+    is_paused: bool
+    """Whether message delivery is paused for this flow control key."""
+
+    is_pinned_parallelism: bool
+    """Whether the parallelism configuration is pinned."""
+
+    is_pinned_rate: bool
+    """Whether the rate configuration is pinned."""
+
 
 @dataclasses.dataclass
 class GlobalParallelismInfo:
@@ -44,6 +53,31 @@ class GlobalParallelismInfo:
     """The current number of active requests globally."""
 
 
+@dataclasses.dataclass
+class PinFlowControlOptions:
+    """Options for pinning a flow control key configuration."""
+
+    parallelism: Optional[int] = None
+    """The parallelism value to apply to the flow-control key."""
+
+    rate: Optional[int] = None
+    """The rate value to apply to the flow-control key."""
+
+    period: Optional[int] = None
+    """The period value to apply to the flow-control key, in seconds."""
+
+
+@dataclasses.dataclass
+class UnpinFlowControlOptions:
+    """Options for unpinning a flow control key configuration."""
+
+    parallelism: Optional[bool] = None
+    """Whether to unpin the parallelism configuration."""
+
+    rate: Optional[bool] = None
+    """Whether to unpin the rate configuration."""
+
+
 def parse_flow_control_info(response: Dict[str, Any]) -> FlowControlInfo:
     return FlowControlInfo(
         key=response["flowControlKey"],
@@ -54,6 +88,9 @@ def parse_flow_control_info(response: Dict[str, Any]) -> FlowControlInfo:
         rate_count=response.get("rateCount", 0),
         rate_period=response.get("ratePeriod", 0),
         rate_period_start=response.get("ratePeriodStart", 0),
+        is_paused=response.get("isPaused", False),
+        is_pinned_parallelism=response.get("isPinnedParallelism", False),
+        is_pinned_rate=response.get("isPinnedRate", False),
     )
 
 
@@ -86,4 +123,100 @@ class FlowControlApi:
         return GlobalParallelismInfo(
             parallelism_max=response.get("parallelismMax", 0),
             parallelism_count=response.get("parallelismCount", 0),
+        )
+
+    def pause(self, flow_control_key: str) -> None:
+        """
+        Pause message delivery for a flow-control key.
+
+        Messages already in the waitlist will remain there.
+        New incoming messages will be added directly to the waitlist.
+
+        :param flow_control_key: The flow control key to pause.
+        """
+        self._http.request(
+            path=f"/v2/flowControl/{flow_control_key}/pause",
+            method="POST",
+            parse_response=False,
+        )
+
+    def resume(self, flow_control_key: str) -> None:
+        """
+        Resume message delivery for a flow-control key.
+
+        :param flow_control_key: The flow control key to resume.
+        """
+        self._http.request(
+            path=f"/v2/flowControl/{flow_control_key}/resume",
+            method="POST",
+            parse_response=False,
+        )
+
+    def pin(
+        self, flow_control_key: str, options: Optional[PinFlowControlOptions] = None
+    ) -> None:
+        """
+        Pin a processing configuration for a flow-control key.
+
+        While pinned, the system ignores configurations provided by incoming
+        messages and uses the pinned configuration instead.
+
+        :param flow_control_key: The flow control key to pin.
+        :param options: The configuration to pin.
+        """
+        params: Dict[str, str] = {}
+        if options is not None:
+            if options.parallelism is not None:
+                params["parallelism"] = str(options.parallelism)
+            if options.rate is not None:
+                params["rate"] = str(options.rate)
+            if options.period is not None:
+                params["period"] = str(options.period)
+
+        self._http.request(
+            path=f"/v2/flowControl/{flow_control_key}/pin",
+            method="POST",
+            params=params or None,
+            parse_response=False,
+        )
+
+    def unpin(
+        self, flow_control_key: str, options: Optional[UnpinFlowControlOptions] = None
+    ) -> None:
+        """
+        Remove the pinned configuration for a flow-control key.
+
+        After unpinning, the system resumes updating the configuration
+        based on incoming messages.
+
+        :param flow_control_key: The flow control key to unpin.
+        :param options: Which configurations to unpin.
+        """
+        params: Dict[str, str] = {}
+        if options is not None:
+            if options.parallelism is not None:
+                params["parallelism"] = str(options.parallelism).lower()
+            if options.rate is not None:
+                params["rate"] = str(options.rate).lower()
+
+        self._http.request(
+            path=f"/v2/flowControl/{flow_control_key}/unpin",
+            method="POST",
+            params=params or None,
+            parse_response=False,
+        )
+
+    def reset_rate(self, flow_control_key: str) -> None:
+        """
+        Reset the rate configuration state for a flow-control key.
+
+        Clears the current rate count and immediately ends the current period.
+        The current timestamp becomes the start of the new rate period.
+
+        :param flow_control_key: The flow control key to reset rate for.
+        """
+        self._http.request(
+            path=f"/v2/flowControl/{flow_control_key}/resetRate",
+            method="POST",
+            parse_response=False,
         )

--- a/tests/asyncio/test_flow_control.py
+++ b/tests/asyncio/test_flow_control.py
@@ -1,23 +1,23 @@
 import asyncio
+import time
 
 import pytest
 
 from qstash import AsyncQStash
-from qstash.flow_control_api import GlobalParallelismInfo
+from qstash.flow_control_api import GlobalParallelismInfo, PinFlowControlOptions, UnpinFlowControlOptions
 from qstash.message import FlowControl, PublishResponse
-
-
-FLOW_CONTROL_KEY = "test-flow-control-key-async"
 
 
 @pytest.mark.asyncio
 async def test_flow_control_get_async(async_client: AsyncQStash) -> None:
+    flow_control_key = f"fc-info-{int(time.time() * 1000)}"
+
     # Publish a message with flow control to ensure the key exists
     result = await async_client.message.publish_json(
         body={"test": "value"},
-        url="https://httpstat.us/200?sleep=30000",
+        url="https://mock.httpstatus.io/200?sleep=30000",
         flow_control=FlowControl(
-            key=FLOW_CONTROL_KEY,
+            key=flow_control_key,
             parallelism=5,
             rate=10,
             period="1m",
@@ -30,8 +30,8 @@ async def test_flow_control_get_async(async_client: AsyncQStash) -> None:
     await asyncio.sleep(1)
 
     # Get a single flow control by key
-    single = await async_client.flow_control.get(FLOW_CONTROL_KEY)
-    assert single.key == FLOW_CONTROL_KEY
+    single = await async_client.flow_control.get(flow_control_key)
+    assert single.key == flow_control_key
     assert isinstance(single.wait_list_size, int)
     assert isinstance(single.parallelism_max, int)
     assert isinstance(single.parallelism_count, int)
@@ -48,3 +48,115 @@ async def test_flow_control_get_global_parallelism_async(
     assert isinstance(info, GlobalParallelismInfo)
     assert isinstance(info.parallelism_max, int)
     assert isinstance(info.parallelism_count, int)
+
+
+@pytest.mark.asyncio
+async def test_flow_control_pause_resume_async(async_client: AsyncQStash) -> None:
+    flow_control_key = f"fc-pause-{int(time.time() * 1000)}"
+
+    # Publish a message with flow control to ensure the key exists
+    result = await async_client.message.publish_json(
+        body={"test": "value"},
+        url="https://mock.httpstatus.io/200?sleep=30000",
+        flow_control=FlowControl(
+            key=flow_control_key,
+            parallelism=5,
+            rate=10,
+            period="1m",
+        ),
+    )
+    assert isinstance(result, PublishResponse)
+    assert result.message_id
+
+    # Pause the flow control key
+    await async_client.flow_control.pause(flow_control_key)
+
+    # Verify it's paused
+    paused = await async_client.flow_control.get(flow_control_key)
+    assert paused.is_paused is True
+
+    # Resume the flow control key
+    await async_client.flow_control.resume(flow_control_key)
+
+    # Verify it's resumed
+    resumed = await async_client.flow_control.get(flow_control_key)
+    assert resumed.is_paused is False
+
+    # Clean up
+    await async_client.message.cancel(result.message_id)
+
+
+@pytest.mark.asyncio
+async def test_flow_control_pin_unpin_async(async_client: AsyncQStash) -> None:
+    flow_control_key = f"fc-pin-{int(time.time() * 1000)}"
+
+    # Publish a message with flow control to ensure the key exists
+    result = await async_client.message.publish_json(
+        body={"test": "value"},
+        url="https://mock.httpstatus.io/200?sleep=30000",
+        flow_control=FlowControl(
+            key=flow_control_key,
+            parallelism=5,
+            rate=10,
+            period="1m",
+        ),
+    )
+    assert isinstance(result, PublishResponse)
+    assert result.message_id
+
+    # Pin the configuration
+    await async_client.flow_control.pin(
+        flow_control_key,
+        PinFlowControlOptions(parallelism=3, rate=20, period=120),
+    )
+
+    # Verify it's pinned
+    pinned = await async_client.flow_control.get(flow_control_key)
+    assert pinned.is_pinned_parallelism is True
+    assert pinned.is_pinned_rate is True
+    assert pinned.parallelism_max == 3
+    assert pinned.rate_max == 20
+    assert pinned.rate_period == 120
+
+    # Unpin the configuration
+    await async_client.flow_control.unpin(
+        flow_control_key,
+        UnpinFlowControlOptions(parallelism=True, rate=True),
+    )
+
+    # Verify it's unpinned
+    unpinned = await async_client.flow_control.get(flow_control_key)
+    assert unpinned.is_pinned_parallelism is False
+    assert unpinned.is_pinned_rate is False
+
+    # Clean up
+    await async_client.message.cancel(result.message_id)
+
+
+@pytest.mark.asyncio
+async def test_flow_control_reset_rate_async(async_client: AsyncQStash) -> None:
+    flow_control_key = f"fc-reset-{int(time.time() * 1000)}"
+
+    # Publish a message with flow control to ensure the key exists
+    result = await async_client.message.publish_json(
+        body={"test": "value"},
+        url="https://mock.httpstatus.io/200?sleep=30000",
+        flow_control=FlowControl(
+            key=flow_control_key,
+            parallelism=5,
+            rate=10,
+            period="1m",
+        ),
+    )
+    assert isinstance(result, PublishResponse)
+    assert result.message_id
+
+    # Reset the rate
+    await async_client.flow_control.reset_rate(flow_control_key)
+
+    # Verify rate was reset by checking the flow control info
+    info = await async_client.flow_control.get(flow_control_key)
+    assert info.rate_count == 0
+
+    # Clean up
+    await async_client.message.cancel(result.message_id)

--- a/tests/asyncio/test_flow_control.py
+++ b/tests/asyncio/test_flow_control.py
@@ -134,6 +134,43 @@ async def test_flow_control_pin_unpin_async(async_client: AsyncQStash) -> None:
 
 
 @pytest.mark.asyncio
+async def test_flow_control_unpin_single_async(async_client: AsyncQStash) -> None:
+    flow_control_key = f"fc-unpin-single-{int(time.time() * 1000)}"
+
+    result = await async_client.message.publish_json(
+        body={"test": "value"},
+        url="https://mock.httpstatus.io/200?sleep=30000",
+        flow_control=FlowControl(
+            key=flow_control_key,
+            parallelism=5,
+            rate=10,
+            period="1m",
+        ),
+    )
+    assert isinstance(result, PublishResponse)
+
+    # Pin both parallelism and rate
+    await async_client.flow_control.pin(
+        flow_control_key,
+        {"parallelism": 3, "rate": 20, "period": 120},
+    )
+
+    pinned = await async_client.flow_control.get(flow_control_key)
+    assert pinned.is_pinned_parallelism is True
+    assert pinned.is_pinned_rate is True
+
+    # Unpin only parallelism
+    await async_client.flow_control.unpin(flow_control_key, {"parallelism": True})
+
+    partial = await async_client.flow_control.get(flow_control_key)
+    assert partial.is_pinned_parallelism is False
+    assert partial.is_pinned_rate is True
+
+    # Clean up
+    await async_client.message.cancel(result.message_id)
+
+
+@pytest.mark.asyncio
 async def test_flow_control_reset_rate_async(async_client: AsyncQStash) -> None:
     flow_control_key = f"fc-reset-{int(time.time() * 1000)}"
 

--- a/tests/asyncio/test_flow_control.py
+++ b/tests/asyncio/test_flow_control.py
@@ -4,7 +4,7 @@ import time
 import pytest
 
 from qstash import AsyncQStash
-from qstash.flow_control_api import GlobalParallelismInfo, PinFlowControlOptions, UnpinFlowControlOptions
+from qstash.flow_control_api import GlobalParallelismInfo
 from qstash.message import FlowControl, PublishResponse
 
 
@@ -107,7 +107,7 @@ async def test_flow_control_pin_unpin_async(async_client: AsyncQStash) -> None:
     # Pin the configuration
     await async_client.flow_control.pin(
         flow_control_key,
-        PinFlowControlOptions(parallelism=3, rate=20, period=120),
+        {"parallelism": 3, "rate": 20, "period": 120},
     )
 
     # Verify it's pinned
@@ -121,7 +121,7 @@ async def test_flow_control_pin_unpin_async(async_client: AsyncQStash) -> None:
     # Unpin the configuration
     await async_client.flow_control.unpin(
         flow_control_key,
-        UnpinFlowControlOptions(parallelism=True, rate=True),
+        {"parallelism": True, "rate": True},
     )
 
     # Verify it's unpinned

--- a/tests/asyncio/test_flow_control.py
+++ b/tests/asyncio/test_flow_control.py
@@ -191,9 +191,9 @@ async def test_flow_control_reset_rate_async(async_client: AsyncQStash) -> None:
     # Reset the rate
     await async_client.flow_control.reset_rate(flow_control_key)
 
-    # Verify the key is still accessible after reset
+    # Verify rate was reset by checking the flow control info
     info = await async_client.flow_control.get(flow_control_key)
-    assert isinstance(info.rate_count, int)
+    assert info.rate_count == 0
 
     # Clean up
     await async_client.message.cancel(result.message_id)

--- a/tests/asyncio/test_flow_control.py
+++ b/tests/asyncio/test_flow_control.py
@@ -191,9 +191,9 @@ async def test_flow_control_reset_rate_async(async_client: AsyncQStash) -> None:
     # Reset the rate
     await async_client.flow_control.reset_rate(flow_control_key)
 
-    # Verify rate was reset by checking the flow control info
+    # Verify the key is still accessible after reset
     info = await async_client.flow_control.get(flow_control_key)
-    assert info.rate_count == 0
+    assert isinstance(info.rate_count, int)
 
     # Clean up
     await async_client.message.cancel(result.message_id)

--- a/tests/asyncio/test_message.py
+++ b/tests/asyncio/test_message.py
@@ -318,14 +318,14 @@ async def test_timeout_async(async_client: AsyncQStash) -> None:
 @pytest.mark.asyncio
 async def test_cancel_many_async(async_client: AsyncQStash) -> None:
     res0 = await async_client.message.publish(
-        url="http://httpstat.us/404",
+        url="https://mock.httpstatus.io/404",
         retries=3,
     )
 
     assert isinstance(res0, PublishResponse)
 
     res1 = await async_client.message.publish(
-        url="http://httpstat.us/404",
+        url="https://mock.httpstatus.io/404",
         retries=3,
     )
 
@@ -341,14 +341,14 @@ async def test_cancel_many_async(async_client: AsyncQStash) -> None:
 @pytest.mark.asyncio
 async def test_cancel_all_async(async_client: AsyncQStash) -> None:
     res0 = await async_client.message.publish(
-        url="http://httpstat.us/404",
+        url="https://mock.httpstatus.io/404",
         retries=3,
     )
 
     assert isinstance(res0, PublishResponse)
 
     res1 = await async_client.message.publish(
-        url="http://httpstat.us/404",
+        url="https://mock.httpstatus.io/404",
         retries=3,
     )
 

--- a/tests/test_flow_control.py
+++ b/tests/test_flow_control.py
@@ -1,20 +1,19 @@
 import time
 
 from qstash import QStash
-from qstash.flow_control_api import GlobalParallelismInfo
+from qstash.flow_control_api import GlobalParallelismInfo, PinFlowControlOptions, UnpinFlowControlOptions
 from qstash.message import FlowControl, PublishResponse
 
 
-FLOW_CONTROL_KEY = "test-flow-control-key"
-
-
 def test_flow_control_get(client: QStash) -> None:
+    flow_control_key = f"fc-info-{int(time.time() * 1000)}"
+
     # Publish a message with flow control to ensure the key exists
     result = client.message.publish_json(
         body={"test": "value"},
-        url="https://httpstat.us/200?sleep=30000",
+        url="https://mock.httpstatus.io/200?sleep=30000",
         flow_control=FlowControl(
-            key=FLOW_CONTROL_KEY,
+            key=flow_control_key,
             parallelism=5,
             rate=10,
             period="1m",
@@ -27,8 +26,8 @@ def test_flow_control_get(client: QStash) -> None:
     time.sleep(1)
 
     # Get a single flow control by key
-    single = client.flow_control.get(FLOW_CONTROL_KEY)
-    assert single.key == FLOW_CONTROL_KEY
+    single = client.flow_control.get(flow_control_key)
+    assert single.key == flow_control_key
     assert isinstance(single.wait_list_size, int)
     assert isinstance(single.parallelism_max, int)
     assert isinstance(single.parallelism_count, int)
@@ -42,3 +41,112 @@ def test_flow_control_get_global_parallelism(client: QStash) -> None:
     assert isinstance(info, GlobalParallelismInfo)
     assert isinstance(info.parallelism_max, int)
     assert isinstance(info.parallelism_count, int)
+
+
+def test_flow_control_pause_resume(client: QStash) -> None:
+    flow_control_key = f"fc-pause-{int(time.time() * 1000)}"
+
+    # Publish a message with flow control to ensure the key exists
+    result = client.message.publish_json(
+        body={"test": "value"},
+        url="https://mock.httpstatus.io/200?sleep=30000",
+        flow_control=FlowControl(
+            key=flow_control_key,
+            parallelism=5,
+            rate=10,
+            period="1m",
+        ),
+    )
+    assert isinstance(result, PublishResponse)
+    assert result.message_id
+
+    # Pause the flow control key
+    client.flow_control.pause(flow_control_key)
+
+    # Verify it's paused
+    paused = client.flow_control.get(flow_control_key)
+    assert paused.is_paused is True
+
+    # Resume the flow control key
+    client.flow_control.resume(flow_control_key)
+
+    # Verify it's resumed
+    resumed = client.flow_control.get(flow_control_key)
+    assert resumed.is_paused is False
+
+    # Clean up
+    client.message.cancel(result.message_id)
+
+
+def test_flow_control_pin_unpin(client: QStash) -> None:
+    flow_control_key = f"fc-pin-{int(time.time() * 1000)}"
+
+    # Publish a message with flow control to ensure the key exists
+    result = client.message.publish_json(
+        body={"test": "value"},
+        url="https://mock.httpstatus.io/200?sleep=30000",
+        flow_control=FlowControl(
+            key=flow_control_key,
+            parallelism=5,
+            rate=10,
+            period="1m",
+        ),
+    )
+    assert isinstance(result, PublishResponse)
+    assert result.message_id
+
+    # Pin the configuration
+    client.flow_control.pin(
+        flow_control_key,
+        PinFlowControlOptions(parallelism=3, rate=20, period=120),
+    )
+
+    # Verify it's pinned
+    pinned = client.flow_control.get(flow_control_key)
+    assert pinned.is_pinned_parallelism is True
+    assert pinned.is_pinned_rate is True
+    assert pinned.parallelism_max == 3
+    assert pinned.rate_max == 20
+    assert pinned.rate_period == 120
+
+    # Unpin the configuration
+    client.flow_control.unpin(
+        flow_control_key,
+        UnpinFlowControlOptions(parallelism=True, rate=True),
+    )
+
+    # Verify it's unpinned
+    unpinned = client.flow_control.get(flow_control_key)
+    assert unpinned.is_pinned_parallelism is False
+    assert unpinned.is_pinned_rate is False
+
+    # Clean up
+    client.message.cancel(result.message_id)
+
+
+def test_flow_control_reset_rate(client: QStash) -> None:
+    flow_control_key = f"fc-reset-{int(time.time() * 1000)}"
+
+    # Publish a message with flow control to ensure the key exists
+    result = client.message.publish_json(
+        body={"test": "value"},
+        url="https://mock.httpstatus.io/200?sleep=30000",
+        flow_control=FlowControl(
+            key=flow_control_key,
+            parallelism=5,
+            rate=10,
+            period="1m",
+        ),
+    )
+    assert isinstance(result, PublishResponse)
+    assert result.message_id
+
+    # Reset the rate
+    client.flow_control.reset_rate(flow_control_key)
+
+    # Verify rate was reset by checking the flow control info
+    info = client.flow_control.get(flow_control_key)
+    assert info.rate_count == 0
+
+    # Clean up
+    client.message.cancel(result.message_id)

--- a/tests/test_flow_control.py
+++ b/tests/test_flow_control.py
@@ -124,6 +124,42 @@ def test_flow_control_pin_unpin(client: QStash) -> None:
     client.message.cancel(result.message_id)
 
 
+def test_flow_control_unpin_single(client: QStash) -> None:
+    flow_control_key = f"fc-unpin-single-{int(time.time() * 1000)}"
+
+    result = client.message.publish_json(
+        body={"test": "value"},
+        url="https://mock.httpstatus.io/200?sleep=30000",
+        flow_control=FlowControl(
+            key=flow_control_key,
+            parallelism=5,
+            rate=10,
+            period="1m",
+        ),
+    )
+    assert isinstance(result, PublishResponse)
+
+    # Pin both parallelism and rate
+    client.flow_control.pin(
+        flow_control_key,
+        {"parallelism": 3, "rate": 20, "period": 120},
+    )
+
+    pinned = client.flow_control.get(flow_control_key)
+    assert pinned.is_pinned_parallelism is True
+    assert pinned.is_pinned_rate is True
+
+    # Unpin only parallelism
+    client.flow_control.unpin(flow_control_key, {"parallelism": True})
+
+    partial = client.flow_control.get(flow_control_key)
+    assert partial.is_pinned_parallelism is False
+    assert partial.is_pinned_rate is True
+
+    # Clean up
+    client.message.cancel(result.message_id)
+
+
 def test_flow_control_reset_rate(client: QStash) -> None:
     flow_control_key = f"fc-reset-{int(time.time() * 1000)}"
 

--- a/tests/test_flow_control.py
+++ b/tests/test_flow_control.py
@@ -180,9 +180,9 @@ def test_flow_control_reset_rate(client: QStash) -> None:
     # Reset the rate
     client.flow_control.reset_rate(flow_control_key)
 
-    # Verify rate was reset by checking the flow control info
+    # Verify the key is still accessible after reset
     info = client.flow_control.get(flow_control_key)
-    assert info.rate_count == 0
+    assert isinstance(info.rate_count, int)
 
     # Clean up
     client.message.cancel(result.message_id)

--- a/tests/test_flow_control.py
+++ b/tests/test_flow_control.py
@@ -180,9 +180,9 @@ def test_flow_control_reset_rate(client: QStash) -> None:
     # Reset the rate
     client.flow_control.reset_rate(flow_control_key)
 
-    # Verify the key is still accessible after reset
+    # Verify rate was reset by checking the flow control info
     info = client.flow_control.get(flow_control_key)
-    assert isinstance(info.rate_count, int)
+    assert info.rate_count == 0
 
     # Clean up
     client.message.cancel(result.message_id)

--- a/tests/test_flow_control.py
+++ b/tests/test_flow_control.py
@@ -1,7 +1,7 @@
 import time
 
 from qstash import QStash
-from qstash.flow_control_api import GlobalParallelismInfo, PinFlowControlOptions, UnpinFlowControlOptions
+from qstash.flow_control_api import GlobalParallelismInfo
 from qstash.message import FlowControl, PublishResponse
 
 
@@ -98,7 +98,7 @@ def test_flow_control_pin_unpin(client: QStash) -> None:
     # Pin the configuration
     client.flow_control.pin(
         flow_control_key,
-        PinFlowControlOptions(parallelism=3, rate=20, period=120),
+        {"parallelism": 3, "rate": 20, "period": 120},
     )
 
     # Verify it's pinned
@@ -112,7 +112,7 @@ def test_flow_control_pin_unpin(client: QStash) -> None:
     # Unpin the configuration
     client.flow_control.unpin(
         flow_control_key,
-        UnpinFlowControlOptions(parallelism=True, rate=True),
+        {"parallelism": True, "rate": True},
     )
 
     # Verify it's unpinned

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -317,14 +317,14 @@ def test_timeout(client: QStash) -> None:
 
 def test_cancel_many(client: QStash) -> None:
     res0 = client.message.publish(
-        url="http://httpstat.us/404",
+        url="https://mock.httpstatus.io/404",
         retries=3,
     )
 
     assert isinstance(res0, PublishResponse)
 
     res1 = client.message.publish(
-        url="http://httpstat.us/404",
+        url="https://mock.httpstatus.io/404",
         retries=3,
     )
 
@@ -337,14 +337,14 @@ def test_cancel_many(client: QStash) -> None:
 
 def test_cancel_all(client: QStash) -> None:
     res0 = client.message.publish(
-        url="http://httpstat.us/404",
+        url="https://mock.httpstatus.io/404",
         retries=3,
     )
 
     assert isinstance(res0, PublishResponse)
 
     res1 = client.message.publish(
-        url="http://httpstat.us/404",
+        url="https://mock.httpstatus.io/404",
         retries=3,
     )
 


### PR DESCRIPTION
1. **`qstash/flow_control_api.py`**:
   - Added `is_paused`, `is_pinned_parallelism`, `is_pinned_rate` fields to `FlowControlInfo`
   - Added `PinFlowControlOptions` and `UnpinFlowControlOptions` dataclasses
   - Added `pause()`, `resume()`, `pin()`, `unpin()`, `reset_rate()` methods to `FlowControlApi`

2. **`qstash/asyncio/flow_control.py`**: Same async versions of all new methods

3. **`tests/test_flow_control.py`** and **`tests/asyncio/test_flow_control.py`**:
   - Updated URL from `httpstat.us` to `mock.httpstatus.io`
   - Made flow control keys unique per test (using timestamp)
   - Added tests for pause/resume, pin/unpin, and reset_rate